### PR TITLE
Fix routing for links to same model instances

### DIFF
--- a/src/react/App.jsx
+++ b/src/react/App.jsx
@@ -25,6 +25,7 @@ export default class App extends React.Component {
 											{...props}
 											documentTitle={route.documentTitle}
 											fetchData={route.fetchData}
+											key={props.match.params.uuid}
 										>
 											<RouteComponent />
 										</FetchDataOnMountWrapper>


### PR DESCRIPTION
On instance pages that include links to different instance pages of the same model, the URL displayed in the browser's address bar would change, but the component would not remount.

The reason is best explained through an example:
- Polonius (character) can be found at this path:
  - `/characters/727bc955-5933-447b-a0a4-77b20c1e6917`.
- The above page includes a link (i.e. `Link` component from `react-router-dom`) to Gravedigger (character) at this path:
  - `/characters/b16af388-68ab-44b2-aafd-1a89734b2fd7`.
- Both paths match `characters/:uuid` in React routes (`src/react/routes.js`).
- The Route component has a `key` value of `index`, acquired from iterating over the routes in `src/react/routes.js`.
- Therefore the routing logic deems those routes the same so will not attempt the component remount lifecycle. For the routing logic to discern the difference between the two paths, a `key` value unique to each specific instance of that model must be added as a property to the component returned by the `Route` component's render function (i.e. `FetchDataOnMountWrapper` component).

### References:
- [Stack Overflow: Component does not remount when route parameters change](https://stackoverflow.com/questions/32261441/component-does-not-remount-when-route-parameters-change#answer-49441836).
- [Stack Overflow: Is it possible to only remount only the new child components on react-router transition](https://stackoverflow.com/questions/31813512/is-it-possible-to-only-remount-only-the-new-child-components-on-react-router-tra#answer-31816415).