### PR TITLE
Use response.send()

### DIFF
--- a/src/server/router.js
+++ b/src/server/router.js
@@ -71,9 +71,7 @@ router.get('*', async (request, response, next) => {
 			</html>
 		`.split('\n').map(line => line.trim()).join('');
 
-		response.write(html);
-
-		response.end();
+		response.send(html);
 
 	} catch (error) {
 


### PR DESCRIPTION
As per Express `res.end()` reference:
> Use to quickly end the response without any data. If you need to respond with data, instead use methods such as res.send() and res.json().

As per first Stack Overflow reference:
> what res.send() does, is to implement **res.write**,**res.setHeaders** and **res.end**

As per second Stack Overflow reference:
> `res.send` can only be called once, since it is equivalent to `res.write` + `res.end()`

### References:
- [Express: res.end()](https://expressjs.com/en/api.html#res.end).
- [Stack Overflow: What is the difference between res.end() and res.send()?](https://stackoverflow.com/questions/29555290/what-is-the-difference-between-res-end-and-res-send#answer-54874227).
- [Stack Overflow: What is the difference between res.send and res.write in express?](https://stackoverflow.com/questions/44692048/what-is-the-difference-between-res-send-and-res-write-in-express#answer-44693016).