### PR TITLE
Amend casing of constants

### DIFF
--- a/src/lib/pluralise-model.js
+++ b/src/lib/pluralise-model.js
@@ -1,3 +1,3 @@
-import { irregularPluralNounsMap } from '../utils/constants';
+import { IRREGULAR_PLURAL_NOUNS_MAP } from '../utils/constants';
 
-export default model => irregularPluralNounsMap[model] || `${model}s`;
+export default model => IRREGULAR_PLURAL_NOUNS_MAP[model] || `${model}s`;

--- a/src/react/components/InstanceLink.jsx
+++ b/src/react/components/InstanceLink.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { irregularPluralNounsMap } from '../../utils/constants';
 import pluraliseModel from '../../lib/pluralise-model';
 
 export default function (props) {

--- a/src/utils/constants.js
+++ b/src/utils/constants.js
@@ -1,7 +1,7 @@
-const irregularPluralNounsMap = {
-	'person': 'people'
+const IRREGULAR_PLURAL_NOUNS_MAP = {
+	person: 'people'
 };
 
 export {
-	irregularPluralNounsMap
+	IRREGULAR_PLURAL_NOUNS_MAP
 };


### PR DESCRIPTION
### References:
- [Airbnb JavaScript Style Guide](https://airbnb.io/javascript/#naming--uppercase).