### PR TITLE
Switch port from 3003 to 3002

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Single-page application (SPA) that provides listings for theatrical productions,
 ## To run locally
 - Compile code: `$ npm run build`; compile and re-compile on change: `$ npm run watch`.
 - Ensure an instance of [`theatrebase-api`](https://github.com/andygout/theatrebase-api) is running on `http://localhost:3000`.
-- Run server using `$ npm start` and visit homepage at `http://localhost:3003`.
+- Run server using `$ npm start` and visit homepage at `http://localhost:3002`.
 
 ## To run linting checks
 - `$ npm run lint-check`.

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -20,7 +20,7 @@ app.use(
 	errorHandler
 );
 
-const port = '3003';
+const port = '3002';
 
 app.set('port', port);
 


### PR DESCRIPTION
It will be easier to remember which port corresponds with each app to keep the alphabetical and numerical order aligned, e.g.
- `theatrebase-api`: 3000.
- `theatrebase-cms`: 3001.
- `theatrebase-spa`: 3002.
- `theatrebase-ssr`: 3003.