### PR TITLE
Amend nodemon.json to watch files in built + public dirs

### DIFF
--- a/nodemon.json
+++ b/nodemon.json
@@ -1,6 +1,7 @@
 {
   "watch": [
-    "src"
+    "built",
+    "public"
   ],
-  "ext": "js jsx"
+  "ext": "css js"
 }


### PR DESCRIPTION
The code is being run from the files in the `built` and `public` dirs (not the `src` dir), so these are the ones that Nodemon needs to be watching.