### PR TITLE
Display instance differentiator

### DIFF
--- a/src/react/components/InstanceDocumentTitle.jsx
+++ b/src/react/components/InstanceDocumentTitle.jsx
@@ -4,16 +4,21 @@ import { Helmet } from 'react-helmet';
 
 const InstanceDocumentTitle = props => {
 
-	const { name, model } = props;
+	const { name, differentiator, model } = props;
+
+	let documentTitle = `${name} (${model})`;
+
+	if (differentiator) documentTitle += ` (${differentiator})`;
 
 	return (
-		<Helmet title={`${name} (${model})`} />
+		<Helmet title={documentTitle} />
 	);
 
 };
 
 InstanceDocumentTitle.propTypes = {
 	name: PropTypes.string.isRequired,
+	differentiator: PropTypes.string,
 	model: PropTypes.string.isRequired
 };
 

--- a/src/react/utils/InstanceWrapper.jsx
+++ b/src/react/utils/InstanceWrapper.jsx
@@ -10,6 +10,12 @@ class InstanceWrapper extends React.Component {
 
 		const { instance, children } = this.props;
 
+		let pageTitleText = instance.get('name', '');
+
+		const differentiator = instance.get('differentiator');
+
+		if (differentiator) pageTitleText += ` (${differentiator})`;
+
 		return (
 			<React.Fragment>
 
@@ -17,6 +23,7 @@ class InstanceWrapper extends React.Component {
 					instance.get('name') && instance.get('model') && (
 						<InstanceDocumentTitle
 							name={instance.get('name')}
+							differentiator={instance.get('differentiator')}
 							model={instance.get('model')}
 						/>
 					)
@@ -24,7 +31,7 @@ class InstanceWrapper extends React.Component {
 
 				<InstanceLabel text={instance.get('model', '')} />
 
-				<PageTitle text={instance.get('name', '')} />
+				<PageTitle text={pageTitleText} />
 
 				{ children }
 


### PR DESCRIPTION
Differentiator will now appear as part of the document title and page title.

#### Before:
<img width="663" alt="demetrius-2-before-spa" src="https://user-images.githubusercontent.com/10484515/91829856-e5bed000-ec39-11ea-851a-270d593708e2.png">

#### After:
<img width="662" alt="demetrius-2-after-spa" src="https://user-images.githubusercontent.com/10484515/91829877-ebb4b100-ec39-11ea-9bcc-49966bc8b206.png">