### PR TITLE
Apply ESLint comma-dangle rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,7 @@
     }
   },
   "rules": {
+    "comma-dangle": 2,
     "eqeqeq": 2,
     "guard-for-in": 2,
     "new-cap": 0,

--- a/src/react/utils/ListWrapper.jsx
+++ b/src/react/utils/ListWrapper.jsx
@@ -26,7 +26,7 @@ class ListWrapper extends React.Component {
 
 ListWrapper.propTypes = {
 	pageTitleText: PropTypes.string.isRequired,
-	instances: ImmutablePropTypes.list.isRequired,
+	instances: ImmutablePropTypes.list.isRequired
 };
 
 export default ListWrapper;


### PR DESCRIPTION
Applies ESLint rule to prevent dangling commas.

### References:
- [ESLint: comma-dangle](https://eslint.org/docs/rules/comma-dangle)