### PR TITLE
Refactor markup

### DIFF
--- a/src/react/components/AppendedDepictions.jsx
+++ b/src/react/components/AppendedDepictions.jsx
@@ -16,19 +16,19 @@ const AppendedDepictions = props => {
 
 							{
 								depiction.get('displayName') && (
-									<span> (as <span className="role-text">{ depiction.get('displayName') }</span>)</span>
+									<React.Fragment>&nbsp;(as <span className="role-text">{ depiction.get('displayName') }</span>)</React.Fragment>
 								)
 							}
 
 							{
 								depiction.get('qualifier') && (
-									<span> ({ depiction.get('qualifier') })</span>
+									<React.Fragment>&nbsp;({ depiction.get('qualifier') })</React.Fragment>
 								)
 							}
 
 							{
 								depiction.get('group') && (
-									<span> ({ depiction.get('group') })</span>
+									<React.Fragment>&nbsp;({ depiction.get('group') })</React.Fragment>
 								)
 							}
 

--- a/src/react/components/AppendedPerformerOtherRoles.jsx
+++ b/src/react/components/AppendedPerformerOtherRoles.jsx
@@ -10,7 +10,7 @@ const AppendedPerformerOtherRoles = props => {
 	return (
 		<React.Fragment>
 
-			<span>; also performed:&nbsp;</span>
+			<React.Fragment>; also performed:&nbsp;</React.Fragment>
 
 			<JoinedRoles instances={otherRoles} />
 

--- a/src/react/components/AppendedPerformers.jsx
+++ b/src/react/components/AppendedPerformers.jsx
@@ -10,7 +10,7 @@ const AppendedPerformers = props => {
 	return (
 		<React.Fragment>
 
-			<span>&nbsp;- performed by:&nbsp;</span>
+			<React.Fragment>&nbsp;- performed by:&nbsp;</React.Fragment>
 
 			{
 				performers
@@ -21,7 +21,7 @@ const AppendedPerformers = props => {
 
 								<InstanceLink instance={performer} />
 
-								<span>&nbsp;…&nbsp;</span>
+								<React.Fragment>&nbsp;…&nbsp;</React.Fragment>
 
 								<span className="role-text">
 									{
@@ -29,7 +29,7 @@ const AppendedPerformers = props => {
 									}
 									{
 										performer.get('qualifier') && (
-											<span> ({ performer.get('qualifier') })</span>
+											<React.Fragment>&nbsp;({ performer.get('qualifier') })</React.Fragment>
 										)
 									}
 								</span>

--- a/src/react/components/AppendedRoles.jsx
+++ b/src/react/components/AppendedRoles.jsx
@@ -10,7 +10,7 @@ const AppendedRoles = props => {
 	return (
 		<React.Fragment>
 
-			<span>&nbsp;…&nbsp;</span>
+			<React.Fragment>&nbsp;…&nbsp;</React.Fragment>
 
 			<JoinedRoles instances={roles} />
 

--- a/src/react/components/AppendedSubTheatres.jsx
+++ b/src/react/components/AppendedSubTheatres.jsx
@@ -8,7 +8,10 @@ const AppendedSubTheatres = props => {
 	const { subTheatres } = props;
 
 	return (
-		<React.Fragment>:&nbsp;
+		<React.Fragment>
+
+			<React.Fragment>:&nbsp;</React.Fragment>
+
 			{
 				subTheatres
 					.map((subTheatre, index) =>
@@ -16,6 +19,7 @@ const AppendedSubTheatres = props => {
 					)
 					.reduce((prev, curr) => [prev, ' / ', curr])
 			}
+
 		</React.Fragment>
 	);
 

--- a/src/react/components/AppendedTheatre.jsx
+++ b/src/react/components/AppendedTheatre.jsx
@@ -10,11 +10,11 @@ const AppendedTheatre = props => {
 	return (
 		<React.Fragment>
 
-			<span>&nbsp;-&nbsp;</span>
+			<React.Fragment>&nbsp;-&nbsp;</React.Fragment>
 
 			{
 				theatre.get('surTheatre') && (
-					<span><InstanceLink instance={theatre.get('surTheatre')} />: </span>
+					<React.Fragment><InstanceLink instance={theatre.get('surTheatre')} />:&nbsp;</React.Fragment>
 				)
 			}
 

--- a/src/react/components/JoinedRoles.jsx
+++ b/src/react/components/JoinedRoles.jsx
@@ -13,7 +13,7 @@ const JoinedRoles = props => {
 			{
 				instances
 					.map((instance, index) =>
-						<span key={index}>
+						<React.Fragment key={index}>
 							{
 								Map.isMap(instance) && instance.get('uuid')
 									? <InstanceLink instance={instance} />
@@ -23,10 +23,10 @@ const JoinedRoles = props => {
 							}
 							{
 								Map.isMap(instance) && instance.get('qualifier') && (
-									<span> ({ instance.get('qualifier') })</span>
+									<React.Fragment>&nbsp;({ instance.get('qualifier') })</React.Fragment>
 								)
 							}
-						</span>
+						</React.Fragment>
 					)
 					.reduce((prev, curr) => [prev, ' / ', curr])
 			}

--- a/src/react/components/List.jsx
+++ b/src/react/components/List.jsx
@@ -24,7 +24,7 @@ const List = props => {
 						{
 							instance.get('uuid')
 								? <InstanceLink instance={instance} />
-								: <span>{ instance.get('name') }</span>
+								: <React.Fragment>{ instance.get('name') }</React.Fragment>
 						}
 
 						{
@@ -71,7 +71,7 @@ const List = props => {
 
 						{
 							instance.get('qualifier') && (
-								<span> ({instance.get('qualifier')})</span>
+								<React.Fragment>&nbsp;({instance.get('qualifier')})</React.Fragment>
 							)
 						}
 


### PR DESCRIPTION
- Replaces `span` tags with `React.Fragment` tags to avoid unnecessary markup.
- Makes usage of `&nbsp;` more consistent.