### PR TITLE
Amend .map() syntax

### DIFF
--- a/src/react/App.jsx
+++ b/src/react/App.jsx
@@ -11,7 +11,7 @@ class App extends React.Component {
 		return (
 			<Switch>
 				{
-					routes.map((route, index) => (
+					routes.map((route, index) =>
 						<Route
 							key={index}
 							path={route.path}
@@ -33,7 +33,7 @@ class App extends React.Component {
 							}
 						/>
 
-					))
+					)
 				}
 			</Switch>
 		);

--- a/src/react/components/List.jsx
+++ b/src/react/components/List.jsx
@@ -18,7 +18,7 @@ const List = props => {
 	return (
 		<ul className="list">
 			{
-				instances.map((instance, index) => (
+				instances.map((instance, index) =>
 					<li key={index}>
 
 						{
@@ -76,7 +76,7 @@ const List = props => {
 						}
 
 					</li>
-				))
+				)
 			}
 		</ul>
 	);

--- a/src/react/pages/instances/Playtext.jsx
+++ b/src/react/pages/instances/Playtext.jsx
@@ -58,7 +58,7 @@ class Playtext extends React.Component {
 										<ul className="list list--no-bullets">
 
 											{
-												characterGroups.map((characterGroup, index) => (
+												characterGroups.map((characterGroup, index) =>
 													<li key={index} className="instance-facet-group">
 
 														{
@@ -70,7 +70,7 @@ class Playtext extends React.Component {
 														<List instances={characterGroup.get('characters')} />
 
 													</li>
-												))
+												)
 											}
 
 										</ul>


### PR DESCRIPTION
Remove unnecessary curly braces and parentheses when using implicit return statement.