### PR TITLE
Fix character materials depictions separator double whitespace

### DIFF
--- a/src/react/components/AppendedDepictions.jsx
+++ b/src/react/components/AppendedDepictions.jsx
@@ -34,7 +34,7 @@ const AppendedDepictions = props => {
 
 						</React.Fragment>
 					)
-					.reduce((prev, curr) => [prev, ' / ', curr])
+					.reduce((prev, curr) => [prev, ' /', curr])
 			}
 
 		</React.Fragment>


### PR DESCRIPTION
Because all the depiction values are prefixed with a `&nbsp;`, when joining multiple depictions (via the `reduce` function), the joining value need not have a tailing whitespace.

#### Before (double whitespace after the forward slash):
![before](https://user-images.githubusercontent.com/10484515/104104493-71a7cf00-52a0-11eb-978d-857b1bbbf79e.png)

---

#### After (single whitespace after the forward slash):
![after](https://user-images.githubusercontent.com/10484515/104104495-74a2bf80-52a0-11eb-91c6-7b7e1d7f2842.png)