### PR TITLE
Disable react/display-name linting rule for single line

### DIFF
--- a/src/react/react-html.jsx
+++ b/src/react/react-html.jsx
@@ -5,7 +5,7 @@ import { StaticRouter } from 'react-router-dom';
 
 import App from './App';
 
-export default (request, store) =>
+export default (request, store) => // eslint-disable-line react/display-name
 	renderToString(
 		<Provider store={store}>
 			<StaticRouter location={request.url} context={{}}>


### PR DESCRIPTION
This PR disables the `react/display-name` linting rule for a single line which is currently causing [CI builds to fail](https://app.circleci.com/pipelines/github/andygout/theatrebase-spa/333/workflows/ecd960e6-b9f5-4c87-8b78-b5dee60494b2/jobs/513) (though cannot be replicated locally):

```
/home/circleci/project/src/react/react-html.jsx
  8:16  error  Component definition is missing display name  react/display-name
```

### References:
- [GitHub: yannickcr/eslint-plugin-react - Rule Details](https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/display-name.md#user-content-rule-details)