### PR TITLE
Make InstanceWrapper children not required

### DIFF
--- a/src/react/utils/InstanceWrapper.jsx
+++ b/src/react/utils/InstanceWrapper.jsx
@@ -52,7 +52,7 @@ class InstanceWrapper extends React.Component {
 InstanceWrapper.propTypes = {
 	instance: ImmutablePropTypes.map.isRequired,
 	titleName: PropTypes.string,
-	children: PropTypes.node.isRequired
+	children: PropTypes.node
 };
 
 export default InstanceWrapper;


### PR DESCRIPTION
Making the following journey produces the below console error:
- Visit home page
- Click on `Award ceremonies` link in navigation
- Click on an award ceremony instance

```
react_devtools_backend.js:4049 Warning: Failed prop type: The prop `children` is marked as required in `InstanceWrapper`, but its value is `undefined`.
    in InstanceWrapper (created by AwardCeremony)
    in AwardCeremony (created by Connect(AwardCeremony))
    in Connect(AwardCeremony) (created by Context.Consumer)
    in main (created by FetchDataOnMountWrapper)
    in FetchDataOnMountWrapper (created by Connect(FetchDataOnMountWrapper))
    in Connect(FetchDataOnMountWrapper) (created by Context.Consumer)
    in Route (created by App)
    in Switch (created by App)
    in App
    in Router (created by BrowserRouter)
    in BrowserRouter
    in Provider
```

This error is caused by trying to render the InstanceWrapper component while still waiting on the data for its children.

It could also have been solved by applying boolean checks as the conditional for rendering (as below), but this fix is more succinct and accommodates the possibility of instances having no facets to display.

#### Before:
```
{
	award && (
		<InstanceFacet labelText='Award'>

			<InstanceLink instance={award} />

		</InstanceFacet>
	)
}
```

#### After:
```
{
	Boolean(award) && (
		<InstanceFacet labelText='Award'>

			<InstanceLink instance={award} />

		</InstanceFacet>
	)
}
```