### PR TITLE
Display award ceremony categories

### DIFF
--- a/src/react/pages/instances/AwardCeremony.jsx
+++ b/src/react/pages/instances/AwardCeremony.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { InstanceFacet, InstanceLink } from '../../components';
+import { InstanceFacet, InstanceLink, List } from '../../components';
 import { InstanceWrapper } from '../../utils';
 
 class AwardCeremony extends React.Component {
@@ -13,6 +13,7 @@ class AwardCeremony extends React.Component {
 		const { awardCeremony } = this.props;
 
 		const award = awardCeremony.get('award');
+		const categories = awardCeremony.get('categories');
 
 		return (
 			<InstanceWrapper instance={awardCeremony}>
@@ -22,6 +23,16 @@ class AwardCeremony extends React.Component {
 						<InstanceFacet labelText='Award'>
 
 							<InstanceLink instance={award} />
+
+						</InstanceFacet>
+					)
+				}
+
+				{
+					categories?.size > 0 && (
+						<InstanceFacet labelText='Categories'>
+
+							<List instances={categories} />
 
 						</InstanceFacet>
 					)


### PR DESCRIPTION
Display material year property exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/447.

---

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="491" alt="award-ceremony-category" src="https://user-images.githubusercontent.com/10484515/133154948-1c1498a5-cc24-4d05-8bdf-ab4c9e8b6f25.png">