### PR TITLE
Display award ceremony category nomination entities

### DIFF
--- a/src/react/components/AppendedCoNominatedEntities.jsx
+++ b/src/react/components/AppendedCoNominatedEntities.jsx
@@ -1,0 +1,29 @@
+import { List } from 'immutable';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { NominatedEntities } from '.';
+
+const AppendedCoNominatedEntities = props => {
+
+	const { coNominatedEntities } = props;
+
+	return (
+		<React.Fragment>
+
+			<React.Fragment>&nbsp;(with&nbsp;</React.Fragment>
+
+			<NominatedEntities nominatedEntities={coNominatedEntities} />
+
+			<React.Fragment>)</React.Fragment>
+
+		</React.Fragment>
+	);
+
+};
+
+AppendedCoNominatedEntities.propTypes = {
+	coNominatedEntities: PropTypes.instanceOf(List).isRequired
+};
+
+export default AppendedCoNominatedEntities;

--- a/src/react/components/AppendedNominatedEmployerCompany.jsx
+++ b/src/react/components/AppendedNominatedEmployerCompany.jsx
@@ -1,0 +1,45 @@
+import { Map } from 'immutable';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { CommaSeparatedInstanceLinks, InstanceLink } from '.';
+
+const AppendedNominatedEmployerCompany = props => {
+
+	const { nominatedEmployerCompany } = props;
+
+	return (
+		<React.Fragment>
+
+			<React.Fragment>&nbsp;(</React.Fragment>
+
+			{
+				nominatedEmployerCompany.get('coNominatedMembers')?.size > 0 && (
+					<React.Fragment>
+
+						<React.Fragment>with&nbsp;</React.Fragment>
+
+						<CommaSeparatedInstanceLinks instances={nominatedEmployerCompany.get('coNominatedMembers')} />
+
+						<React.Fragment>&nbsp;</React.Fragment>
+
+					</React.Fragment>
+				)
+			}
+
+			<React.Fragment>for&nbsp;</React.Fragment>
+
+			<InstanceLink instance={nominatedEmployerCompany} />
+
+			<React.Fragment>)</React.Fragment>
+
+		</React.Fragment>
+	);
+
+};
+
+AppendedNominatedEmployerCompany.propTypes = {
+	nominatedEmployerCompany: PropTypes.instanceOf(Map).isRequired
+};
+
+export default AppendedNominatedEmployerCompany;

--- a/src/react/components/AppendedNominatedMembers.jsx
+++ b/src/react/components/AppendedNominatedMembers.jsx
@@ -1,0 +1,29 @@
+import { List } from 'immutable';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { CommaSeparatedInstanceLinks } from '.';
+
+const AppendedNominatedMembers = props => {
+
+	const { nominatedMembers } = props;
+
+	return (
+		<React.Fragment>
+
+			<React.Fragment>&nbsp;(</React.Fragment>
+
+			<CommaSeparatedInstanceLinks instances={nominatedMembers} />
+
+			<React.Fragment>)</React.Fragment>
+
+		</React.Fragment>
+	);
+
+};
+
+AppendedNominatedMembers.propTypes = {
+	nominatedMembers: PropTypes.instanceOf(List).isRequired
+};
+
+export default AppendedNominatedMembers;

--- a/src/react/components/NominatedEntities.jsx
+++ b/src/react/components/NominatedEntities.jsx
@@ -1,0 +1,41 @@
+import { List } from 'immutable';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { AppendedNominatedMembers, InstanceLink } from '.';
+
+const NominatedEntities = props => {
+
+	const { nominatedEntities } = props;
+
+	return (
+		<React.Fragment>
+
+			{
+				nominatedEntities
+					.map((nominatedEntity, index) =>
+						<React.Fragment key={index}>
+
+							<InstanceLink instance={nominatedEntity} />
+
+							{
+								nominatedEntity.get('nominatedMembers')?.size > 0 && (
+									<AppendedNominatedMembers nominatedMembers={nominatedEntity.get('nominatedMembers')} />
+								)
+							}
+
+						</React.Fragment>
+					)
+					.reduce((prev, curr) => [prev, ', ', curr])
+			}
+
+		</React.Fragment>
+	);
+
+};
+
+NominatedEntities.propTypes = {
+	nominatedEntities: PropTypes.instanceOf(List).isRequired
+};
+
+export default NominatedEntities;

--- a/src/react/components/index.js
+++ b/src/react/components/index.js
@@ -1,9 +1,12 @@
 import AppendedCoCreditedEntities from './AppendedCoCreditedEntities';
+import AppendedCoNominatedEntities from './AppendedCoNominatedEntities';
 import AppendedCreditedEmployerCompany from './AppendedCreditedEmployerCompany';
 import AppendedCreditedMembers from './AppendedCreditedMembers';
 import AppendedDepictions from './AppendedDepictions';
 import AppendedEntities from './AppendedEntities';
 import AppendedFormatAndYear from './AppendedFormatAndYear';
+import AppendedNominatedEmployerCompany from './AppendedNominatedEmployerCompany';
+import AppendedNominatedMembers from './AppendedNominatedMembers';
 import AppendedPerformers from './AppendedPerformers';
 import AppendedPerformerOtherRoles from './AppendedPerformerOtherRoles';
 import AppendedProductionDates from './AppendedProductionDates';
@@ -25,6 +28,7 @@ import InstanceLink from './InstanceLink';
 import JoinedRoles from './JoinedRoles';
 import List from './List';
 import Navigation from './Navigation';
+import NominatedEntities from './NominatedEntities';
 import PageTitle from './PageTitle';
 import PrependedAward from './PrependedAward';
 import PrependedCreditedMembers from './PrependedCreditedMembers';
@@ -35,11 +39,14 @@ import WritingEntities from './WritingEntities';
 
 export {
 	AppendedCoCreditedEntities,
+	AppendedCoNominatedEntities,
 	AppendedCreditedEmployerCompany,
 	AppendedCreditedMembers,
 	AppendedDepictions,
 	AppendedEntities,
 	AppendedFormatAndYear,
+	AppendedNominatedEmployerCompany,
+	AppendedNominatedMembers,
 	AppendedPerformers,
 	AppendedPerformerOtherRoles,
 	AppendedProductionDates,
@@ -61,6 +68,7 @@ export {
 	JoinedRoles,
 	List,
 	Navigation,
+	NominatedEntities,
 	PageTitle,
 	PrependedAward,
 	PrependedCreditedMembers,

--- a/src/react/pages/instances/Award.jsx
+++ b/src/react/pages/instances/Award.jsx
@@ -12,16 +12,16 @@ class Award extends React.Component {
 
 		const { award } = this.props;
 
-		const awardCeremonies = award.get('awardCeremonies');
+		const ceremonies = award.get('ceremonies');
 
 		return (
 			<InstanceWrapper instance={award}>
 
 				{
-					awardCeremonies?.size > 0 && (
+					ceremonies?.size > 0 && (
 						<InstanceFacet labelText='Award ceremonies'>
 
-							<List instances={awardCeremonies} />
+							<List instances={ceremonies} />
 
 						</InstanceFacet>
 					)

--- a/src/react/pages/instances/AwardCeremony.jsx
+++ b/src/react/pages/instances/AwardCeremony.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { InstanceFacet, InstanceLink, List } from '../../components';
+import { InstanceFacet, InstanceLink, NominatedEntities } from '../../components';
 import { InstanceWrapper } from '../../utils';
 
 class AwardCeremony extends React.Component {
@@ -32,7 +32,25 @@ class AwardCeremony extends React.Component {
 					categories?.size > 0 && (
 						<InstanceFacet labelText='Categories'>
 
-							<List instances={categories} />
+							{
+								categories.map((category, index) =>
+									<React.Fragment key={index}>
+										{ category.get('name') }
+
+										<ul className="list">
+
+											{
+												category.get('nominations').map((nomination, index) =>
+													<li key={index}>
+														<NominatedEntities nominatedEntities={nomination.get('entities')} />
+													</li>
+												)
+											}
+
+										</ul>
+									</React.Fragment>
+								)
+							}
 
 						</InstanceFacet>
 					)

--- a/src/react/pages/instances/Company.jsx
+++ b/src/react/pages/instances/Company.jsx
@@ -3,7 +3,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { InstanceFacet, List } from '../../components';
+import {
+	AppendedCoNominatedEntities,
+	AppendedNominatedMembers,
+	InstanceFacet,
+	InstanceLink,
+	List
+} from '../../components';
 import { InstanceWrapper } from '../../utils';
 
 class Company extends React.Component {
@@ -19,6 +25,7 @@ class Company extends React.Component {
 		const producerProductions = company.get('producerProductions');
 		const creativeProductions = company.get('creativeProductions');
 		const crewProductions = company.get('crewProductions');
+		const awards = company.get('awards');
 
 		return (
 			<InstanceWrapper instance={company}>
@@ -92,6 +99,70 @@ class Company extends React.Component {
 						</InstanceFacet>
 					)
 				}
+
+			{
+				awards?.size > 0 && (
+					<InstanceFacet labelText='Awards'>
+
+						{
+							awards.map((award, index) =>
+								<React.Fragment key={index}>
+									<InstanceLink instance={award} />
+
+									<ul className="list">
+
+										{
+											award.get('ceremonies').map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
+
+													{
+														ceremony.get('categories')
+															.map((category, index) =>
+																<React.Fragment key={index}>
+																	{ category.get('name') }{': '}
+
+																	{
+																		category.get('nominations')
+																			.map((nomination, index) =>
+																				<React.Fragment key={index}>
+																					{'Nomination'}
+
+																					{
+																						nomination.get('nominatedMembers')?.size > 0 && (
+																							<AppendedNominatedMembers
+																								nominatedMembers={nomination.get('nominatedMembers')}
+																							/>
+																						)
+																					}
+
+																					{
+																						nomination.get('coNominatedEntities').size > 0 && (
+																							<AppendedCoNominatedEntities
+																								coNominatedEntities={nomination.get('coNominatedEntities')}
+																							/>
+																						)
+																					}
+																				</React.Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</React.Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
+
+									</ul>
+								</React.Fragment>
+							)
+						}
+
+					</InstanceFacet>
+				)
+			}
 
 			</InstanceWrapper>
 		);

--- a/src/react/pages/instances/Person.jsx
+++ b/src/react/pages/instances/Person.jsx
@@ -3,7 +3,13 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { InstanceFacet, List } from '../../components';
+import {
+	AppendedNominatedEmployerCompany,
+	AppendedCoNominatedEntities,
+	InstanceFacet,
+	InstanceLink,
+	List
+} from '../../components';
 import { InstanceWrapper } from '../../utils';
 
 class Person extends React.Component {
@@ -20,6 +26,7 @@ class Person extends React.Component {
 		const castMemberProductions = person.get('castMemberProductions');
 		const creativeProductions = person.get('creativeProductions');
 		const crewProductions = person.get('crewProductions');
+		const awards = person.get('awards');
 
 		return (
 			<InstanceWrapper instance={person}>
@@ -103,6 +110,70 @@ class Person extends React.Component {
 						</InstanceFacet>
 					)
 				}
+
+			{
+				awards?.size > 0 && (
+					<InstanceFacet labelText='Awards'>
+
+						{
+							awards.map((award, index) =>
+								<React.Fragment key={index}>
+									<InstanceLink instance={award} />
+
+									<ul className="list">
+
+										{
+											award.get('ceremonies').map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
+
+													{
+														ceremony.get('categories')
+															.map((category, index) =>
+																<React.Fragment key={index}>
+																	{ category.get('name') }{': '}
+
+																	{
+																		category.get('nominations')
+																			.map((nomination, index) =>
+																				<React.Fragment key={index}>
+																					{'Nomination'}
+
+																					{
+																						nomination.get('nominatedEmployerCompany') && (
+																							<AppendedNominatedEmployerCompany
+																								nominatedEmployerCompany={nomination.get('nominatedEmployerCompany')}
+																							/>
+																						)
+																					}
+
+																					{
+																						nomination.get('coNominatedEntities').size > 0 && (
+																							<AppendedCoNominatedEntities
+																								coNominatedEntities={nomination.get('coNominatedEntities')}
+																							/>
+																						)
+																					}
+																				</React.Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</React.Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
+
+									</ul>
+								</React.Fragment>
+							)
+						}
+
+					</InstanceFacet>
+				)
+			}
 
 			</InstanceWrapper>
 		);


### PR DESCRIPTION
Display award ceremony category nomination entities exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/448.

---

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="823" alt="laurence-olivier-awards-2020" src="https://user-images.githubusercontent.com/10484515/141331773-ba37ef09-ff06-43fa-bad6-3164d8bee19c.png">

---

#### John Doe (person)
<img width="925" alt="john-doe-person" src="https://user-images.githubusercontent.com/10484515/141332369-6f2b5bfb-91e6-4ce9-b3ff-78abf033e814.png">

---

#### Curtain Up Ltd (company)
<img width="669" alt="curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/141332373-17512eea-9754-4534-a275-ca17b7771fbe.png">

---

#### Conor Corge (person)
<img width="936" alt="conor-corge-person" src="https://user-images.githubusercontent.com/10484515/141332402-c4340d2d-aec5-4d2e-a54a-2accb0f2c096.png">

---

#### Stagecraft Ltd (company)
<img width="911" alt="stagecraft-ltd-company" src="https://user-images.githubusercontent.com/10484515/141332400-fd1d4b01-2074-4b59-8e21-b4c7fc994145.png">

---

#### Quincy Qux (person)
<img width="927" alt="quincy-qux-person" src="https://user-images.githubusercontent.com/10484515/141332395-32db56ee-7d73-4e7b-8253-04155cfd33e8.png">