### PR TITLE
Replace nomination customType with type

### DIFF
--- a/src/react/pages/instances/AwardCeremony.jsx
+++ b/src/react/pages/instances/AwardCeremony.jsx
@@ -42,13 +42,7 @@ class AwardCeremony extends React.Component {
 											{
 												category.get('nominations').map((nomination, index) =>
 													<li key={index}>
-														{
-															nomination.get('customType')
-																? (<span>{`${nomination.get('customType')}: `}</span>)
-																: nomination.get('isWinner')
-																	? (<span>{'Winner: '}</span>)
-																	: (<span>{'Nomination: '}</span>)
-														}
+														<span>{`${nomination.get('type')}: `}</span>
 
 														{
 															nomination.get('entities').size > 0 && (

--- a/src/react/pages/instances/Company.jsx
+++ b/src/react/pages/instances/Company.jsx
@@ -132,13 +132,7 @@ class Company extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						{
-																							nomination.get('customType')
-																								? (<span>{nomination.get('customType')}</span>)
-																								: nomination.get('isWinner')
-																									? (<span>{'Winner'}</span>)
-																									: (<span>{'Nomination'}</span>)
-																						}
+																						<span>{nomination.get('type')}</span>
 
 																						{
 																							nomination.get('members')?.size > 0 && (
@@ -231,13 +225,7 @@ class Company extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						{
-																							nomination.get('customType')
-																								? (<span>{nomination.get('customType')}</span>)
-																								: nomination.get('isWinner')
-																									? (<span>{'Winner'}</span>)
-																									: (<span>{'Nomination'}</span>)
-																						}
+																						<span>{nomination.get('type')}</span>
 
 																						{
 																							nomination.get('subsequentVersionMaterials').size > 0 && (
@@ -341,13 +329,7 @@ class Company extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						{
-																							nomination.get('customType')
-																								? (<span>{nomination.get('customType')}</span>)
-																								: nomination.get('isWinner')
-																									? (<span>{'Winner'}</span>)
-																									: (<span>{'Nomination'}</span>)
-																						}
+																						<span>{nomination.get('type')}</span>
 
 																						{
 																							nomination.get('sourcingMaterials').size > 0 && (
@@ -451,13 +433,7 @@ class Company extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						{
-																							nomination.get('customType')
-																								? (<span>{nomination.get('customType')}</span>)
-																								: nomination.get('isWinner')
-																									? (<span>{'Winner'}</span>)
-																									: (<span>{'Nomination'}</span>)
-																						}
+																						<span>{nomination.get('type')}</span>
 
 																						{
 																							nomination.get('rightsGrantorMaterials').size > 0 && (

--- a/src/react/pages/instances/Material.jsx
+++ b/src/react/pages/instances/Material.jsx
@@ -209,13 +209,7 @@ class Material extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						{
-																							nomination.get('customType')
-																								? (<span>{nomination.get('customType')}</span>)
-																								: nomination.get('isWinner')
-																									? (<span>{'Winner'}</span>)
-																									: (<span>{'Nomination'}</span>)
-																						}
+																						<span>{nomination.get('type')}</span>
 
 																						{
 																							nomination.get('entities').size > 0 && (
@@ -304,13 +298,7 @@ class Material extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						{
-																							nomination.get('customType')
-																								? (<span>{nomination.get('customType')}</span>)
-																								: nomination.get('isWinner')
-																									? (<span>{'Winner'}</span>)
-																									: (<span>{'Nomination'}</span>)
-																						}
+																						<span>{nomination.get('type')}</span>
 
 																						{
 																							nomination.get('subsequentVersionMaterials').size > 0 && (
@@ -410,13 +398,7 @@ class Material extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						{
-																							nomination.get('customType')
-																								? (<span>{nomination.get('customType')}</span>)
-																								: nomination.get('isWinner')
-																									? (<span>{'Winner'}</span>)
-																									: (<span>{'Nomination'}</span>)
-																						}
+																						<span>{nomination.get('type')}</span>
 
 																						{
 																							nomination.get('sourcingMaterials').size > 0 && (

--- a/src/react/pages/instances/Person.jsx
+++ b/src/react/pages/instances/Person.jsx
@@ -143,13 +143,7 @@ class Person extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						{
-																							nomination.get('customType')
-																								? (<span>{nomination.get('customType')}</span>)
-																								: nomination.get('isWinner')
-																									? (<span>{'Winner'}</span>)
-																									: (<span>{'Nomination'}</span>)
-																						}
+																						<span>{nomination.get('type')}</span>
 
 																						{
 																							nomination.get('employerCompany') && (
@@ -242,13 +236,7 @@ class Person extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						{
-																							nomination.get('customType')
-																								? (<span>{nomination.get('customType')}</span>)
-																								: nomination.get('isWinner')
-																									? (<span>{'Winner'}</span>)
-																									: (<span>{'Nomination'}</span>)
-																						}
+																						<span>{nomination.get('type')}</span>
 
 																						{
 																							nomination.get('subsequentVersionMaterials').size > 0 && (
@@ -352,13 +340,7 @@ class Person extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						{
-																							nomination.get('customType')
-																								? (<span>{nomination.get('customType')}</span>)
-																								: nomination.get('isWinner')
-																									? (<span>{'Winner'}</span>)
-																									: (<span>{'Nomination'}</span>)
-																						}
+																						<span>{nomination.get('type')}</span>
 
 																						{
 																							nomination.get('sourcingMaterials').size > 0 && (
@@ -462,13 +444,7 @@ class Person extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						{
-																							nomination.get('customType')
-																								? (<span>{nomination.get('customType')}</span>)
-																								: nomination.get('isWinner')
-																									? (<span>{'Winner'}</span>)
-																									: (<span>{'Nomination'}</span>)
-																						}
+																						<span>{nomination.get('type')}</span>
 
 																						{
 																							nomination.get('rightsGrantorMaterials').size > 0 && (

--- a/src/react/pages/instances/Production.jsx
+++ b/src/react/pages/instances/Production.jsx
@@ -178,13 +178,7 @@ class Production extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						{
-																							nomination.get('customType')
-																								? (<span>{nomination.get('customType')}</span>)
-																								: nomination.get('isWinner')
-																									? (<span>{'Winner'}</span>)
-																									: (<span>{'Nomination'}</span>)
-																						}
+																						<span>{nomination.get('type')}</span>
 
 																						{
 																							nomination.get('entities').size > 0 && (


### PR DESCRIPTION
Replace nomination `customType` property with `type` as exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/481.

The API change allows this app to passively display the `type` value rather than have to calculate the value to display itself.