### PR TITLE
Style nomination winners in bold

### DIFF
--- a/src/client/stylesheets/_text.scss
+++ b/src/client/stylesheets/_text.scss
@@ -8,3 +8,7 @@
 .role-text {
 	font-style: italic;
 }
+
+.nomination-winner-text {
+	font-weight: bold;
+}

--- a/src/react/pages/instances/AwardCeremony.jsx
+++ b/src/react/pages/instances/AwardCeremony.jsx
@@ -42,7 +42,9 @@ class AwardCeremony extends React.Component {
 											{
 												category.get('nominations').map((nomination, index) =>
 													<li key={index}>
-														<span>{`${nomination.get('type')}: `}</span>
+														<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+															{`${nomination.get('type')}: `}
+														</span>
 
 														{
 															nomination.get('entities').size > 0 && (

--- a/src/react/pages/instances/Company.jsx
+++ b/src/react/pages/instances/Company.jsx
@@ -132,7 +132,9 @@ class Company extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						<span>{nomination.get('type')}</span>
+																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																							{nomination.get('type')}
+																						</span>
 
 																						{
 																							nomination.get('members')?.size > 0 && (
@@ -225,7 +227,9 @@ class Company extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						<span>{nomination.get('type')}</span>
+																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																							{nomination.get('type')}
+																						</span>
 
 																						{
 																							nomination.get('subsequentVersionMaterials').size > 0 && (
@@ -329,7 +333,9 @@ class Company extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						<span>{nomination.get('type')}</span>
+																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																							{nomination.get('type')}
+																						</span>
 
 																						{
 																							nomination.get('sourcingMaterials').size > 0 && (
@@ -433,7 +439,9 @@ class Company extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						<span>{nomination.get('type')}</span>
+																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																							{nomination.get('type')}
+																						</span>
 
 																						{
 																							nomination.get('rightsGrantorMaterials').size > 0 && (

--- a/src/react/pages/instances/Material.jsx
+++ b/src/react/pages/instances/Material.jsx
@@ -209,7 +209,9 @@ class Material extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						<span>{nomination.get('type')}</span>
+																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																							{nomination.get('type')}
+																						</span>
 
 																						{
 																							nomination.get('entities').size > 0 && (
@@ -298,7 +300,9 @@ class Material extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						<span>{nomination.get('type')}</span>
+																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																							{nomination.get('type')}
+																						</span>
 
 																						{
 																							nomination.get('subsequentVersionMaterials').size > 0 && (
@@ -398,7 +402,9 @@ class Material extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						<span>{nomination.get('type')}</span>
+																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																							{nomination.get('type')}
+																						</span>
 
 																						{
 																							nomination.get('sourcingMaterials').size > 0 && (

--- a/src/react/pages/instances/Person.jsx
+++ b/src/react/pages/instances/Person.jsx
@@ -143,7 +143,9 @@ class Person extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						<span>{nomination.get('type')}</span>
+																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																							{nomination.get('type')}
+																						</span>
 
 																						{
 																							nomination.get('employerCompany') && (
@@ -236,7 +238,9 @@ class Person extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						<span>{nomination.get('type')}</span>
+																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																							{nomination.get('type')}
+																						</span>
 
 																						{
 																							nomination.get('subsequentVersionMaterials').size > 0 && (
@@ -340,7 +344,9 @@ class Person extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						<span>{nomination.get('type')}</span>
+																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																							{nomination.get('type')}
+																						</span>
 
 																						{
 																							nomination.get('sourcingMaterials').size > 0 && (
@@ -444,7 +450,9 @@ class Person extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						<span>{nomination.get('type')}</span>
+																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																							{nomination.get('type')}
+																						</span>
 
 																						{
 																							nomination.get('rightsGrantorMaterials').size > 0 && (

--- a/src/react/pages/instances/Production.jsx
+++ b/src/react/pages/instances/Production.jsx
@@ -178,7 +178,9 @@ class Production extends React.Component {
 																			category.get('nominations')
 																				.map((nomination, index) =>
 																					<React.Fragment key={index}>
-																						<span>{nomination.get('type')}</span>
+																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																							{nomination.get('type')}
+																						</span>
 
 																						{
 																							nomination.get('entities').size > 0 && (


### PR DESCRIPTION
This PR applies styling to the text that describes the nomination type when the nomination was the winner in its category.

---

#### Laurence Olivier Awards 2008 (award ceremony)
<img width="946" alt="laurence-olivier-awards-2008-award-ceremony" src="https://user-images.githubusercontent.com/10484515/162067517-6c5ca7f5-c952-4dfa-8c08-9475452e7822.png">

---

#### Macbeth at Gielgud Theatre (production)
<img width="553" alt="macbeth-gielgud-theatre-production" src="https://user-images.githubusercontent.com/10484515/162067542-6242e2f7-0d86-42c3-8650-e010db84d183.png">

---

#### Black Watch (material)
<img width="545" alt="black-watch-material" src="https://user-images.githubusercontent.com/10484515/162067564-c22586cc-5788-4222-b597-2b67505bb128.png">

---

#### Patrick Stewart (person)
<img width="468" alt="patrick-stewart-person" src="https://user-images.githubusercontent.com/10484515/162067583-62688311-12f6-4a9b-a659-f7015e3106bb.png">

---

#### Théâtre de Complicité (company)
<img width="845" alt="théâtre-de-complicité-company" src="https://user-images.githubusercontent.com/10484515/162067594-8c3286a6-999b-4c66-ab1b-ce7026bb40fb.png">