### PR TITLE
Display material sub-materials

### DIFF
--- a/src/lib/get-instance-title.js
+++ b/src/lib/get-instance-title.js
@@ -12,6 +12,10 @@ export default instance => {
 			if (instance.get('award')) title = `${instance.getIn(['award', 'name'])} ${title}`;
 			return title;
 
+		case MODELS.MATERIAL:
+			if (instance.get('surMaterial')) title = `${instance.getIn(['surMaterial', 'name'])}: ${title}`;
+			return title;
+
 		case MODELS.VENUE:
 			if (instance.get('surVenue')) title = `${instance.getIn(['surVenue', 'name'])}: ${title}`;
 			return title;

--- a/src/react/components/List.jsx
+++ b/src/react/components/List.jsx
@@ -15,7 +15,8 @@ import {
 	AppendedVenue,
 	AppendedWritingCredits,
 	InstanceLink,
-	PrependedAward
+	PrependedAward,
+	PrependedSurMaterial
 } from '.';
 
 const List = props => {
@@ -32,6 +33,12 @@ const List = props => {
 						{
 							instance.get('award') && (
 								<PrependedAward award={instance.get('award')} />
+							)
+						}
+
+						{
+							instance.get('surMaterial') && (
+								<PrependedSurMaterial surMaterial={instance.get('surMaterial')} />
 							)
 						}
 

--- a/src/react/components/Materials.jsx
+++ b/src/react/components/Materials.jsx
@@ -2,7 +2,7 @@ import { List } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { AppendedFormatAndYear, AppendedWritingCredits, InstanceLink } from '.';
+import { AppendedFormatAndYear, AppendedWritingCredits, InstanceLink, PrependedSurMaterial } from '.';
 
 const Materials = props => {
 
@@ -15,6 +15,12 @@ const Materials = props => {
 				materials
 					.map((material, index) =>
 						<React.Fragment key={index}>
+
+							{
+								material.get('surMaterial') && (
+									<PrependedSurMaterial surMaterial={material.get('surMaterial')} />
+								)
+							}
 
 							<InstanceLink instance={material} />
 

--- a/src/react/components/PrependedSurMaterial.jsx
+++ b/src/react/components/PrependedSurMaterial.jsx
@@ -1,0 +1,27 @@
+import { Map } from 'immutable';
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { InstanceLink } from '.';
+
+const PrependedSurMaterial = props => {
+
+	const { surMaterial } = props;
+
+	return (
+		<React.Fragment>
+
+			<InstanceLink instance={surMaterial} />
+
+			<React.Fragment>{': '}</React.Fragment>
+
+		</React.Fragment>
+	);
+
+};
+
+PrependedSurMaterial.propTypes = {
+	surMaterial: PropTypes.instanceOf(Map).isRequired
+};
+
+export default PrependedSurMaterial;

--- a/src/react/components/WritingEntities.jsx
+++ b/src/react/components/WritingEntities.jsx
@@ -2,7 +2,7 @@ import { List } from 'immutable';
 import PropTypes from 'prop-types';
 import React from 'react';
 
-import { AppendedFormatAndYear, InstanceLink, WritingCredits } from '.';
+import { AppendedFormatAndYear, InstanceLink, PrependedSurMaterial, WritingCredits } from '.';
 
 const WritingEntities = props => {
 
@@ -15,6 +15,12 @@ const WritingEntities = props => {
 				entities
 					.map((entity, index) =>
 						<React.Fragment key={index}>
+
+							{
+								entity.get('surMaterial') && (
+									<PrependedSurMaterial surMaterial={entity.get('surMaterial')} />
+								)
+							}
 
 							{
 								entity.get('uuid')

--- a/src/react/components/index.js
+++ b/src/react/components/index.js
@@ -29,6 +29,7 @@ import Navigation from './Navigation';
 import PageTitle from './PageTitle';
 import PrependedAward from './PrependedAward';
 import PrependedMembers from './PrependedMembers';
+import PrependedSurMaterial from './PrependedSurMaterial';
 import ProducerCredits from './ProducerCredits';
 import ProducerEntities from './ProducerEntities';
 import Productions from './Productions';
@@ -67,6 +68,7 @@ export {
 	PageTitle,
 	PrependedAward,
 	PrependedMembers,
+	PrependedSurMaterial,
 	ProducerCredits,
 	ProducerEntities,
 	Productions,

--- a/src/react/pages/instances/Material.jsx
+++ b/src/react/pages/instances/Material.jsx
@@ -26,6 +26,8 @@ class Material extends React.Component {
 		const format = material.get('format');
 		const year = material.get('year');
 		const writingCredits = material.get('writingCredits');
+		const surMaterial = material.get('surMaterial');
+		const subMaterials = material.get('subMaterials');
 		const characterGroups = material.get('characterGroups');
 		const originalVersionMaterial = material.get('originalVersionMaterial');
 		const subsequentVersionMaterials = material.get('subsequentVersionMaterials');
@@ -67,6 +69,41 @@ class Material extends React.Component {
 						<InstanceFacet labelText='Writers'>
 
 							<WritingCredits credits={writingCredits} isAppendage={false} />
+
+						</InstanceFacet>
+					)
+				}
+
+				{
+					surMaterial && (
+						<InstanceFacet labelText='Part of'>
+
+							<InstanceLink instance={surMaterial} />
+
+							{
+								(surMaterial.get('format') || surMaterial.get('year')) && (
+									<AppendedFormatAndYear
+										format={surMaterial.get('format')}
+										year={surMaterial.get('year')}
+									/>
+								)
+							}
+
+							{
+								surMaterial.get('writingCredits')?.size > 0 && (
+									<AppendedWritingCredits credits={surMaterial.get('writingCredits')} />
+								)
+							}
+
+						</InstanceFacet>
+					)
+				}
+
+				{
+					subMaterials?.size > 0 && (
+						<InstanceFacet labelText='Comprises'>
+
+							<List instances={subMaterials} />
 
 						</InstanceFacet>
 					)
@@ -237,6 +274,31 @@ class Material extends React.Component {
 
 																						{
 																							nomination.get('productions').size > 0 &&
+																							(nomination.get('recipientMaterial') || nomination.get('coMaterials').size > 0) && (
+																								<React.Fragment>{';'}</React.Fragment>
+																							)
+																						}
+
+																						{
+																							nomination.get('recipientMaterial') && (
+																								<React.Fragment>
+																									<React.Fragment>{' (for '}</React.Fragment>
+																									<InstanceLink instance={nomination.get('recipientMaterial')} />
+																									{
+																										(nomination.getIn(['recipientMaterial', 'format']) || nomination.getIn(['recipientMaterial', 'year'])) && (
+																											<AppendedFormatAndYear
+																												format={nomination.getIn(['recipientMaterial', 'format'])}
+																												year={nomination.getIn(['recipientMaterial', 'year'])}
+																											/>
+																										)
+																									}
+																									<React.Fragment>{')'}</React.Fragment>
+																								</React.Fragment>
+																							)
+																						}
+
+																						{
+																							nomination.get('recipientMaterial') &&
 																							nomination.get('coMaterials').size > 0 && (
 																								<React.Fragment>{';'}</React.Fragment>
 																							)

--- a/src/react/pages/instances/Production.jsx
+++ b/src/react/pages/instances/Production.jsx
@@ -12,6 +12,7 @@ import {
 	InstanceLink,
 	List,
 	Materials,
+	PrependedSurMaterial,
 	ProducerCredits,
 	Productions
 } from '../../components';
@@ -42,6 +43,12 @@ class Production extends React.Component {
 				{
 					material && (
 						<InstanceFacet labelText='Material'>
+
+							{
+								material.get('surMaterial') && (
+									<PrependedSurMaterial surMaterial={material.get('surMaterial')} />
+								)
+							}
 
 							<InstanceLink instance={material} />
 


### PR DESCRIPTION
Display material sub-materials exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/485.

N.B. Several contrived companies/materials/people/productions have been used for the purposes of demonstration.

### References:
- [The Guardian: Triple threat: the trouble with theatrical trilogies](https://www.theguardian.com/stage/2014/oct/03/triple-threat-theatrical-trilogies)

---

## Real-life examples

#### The Coast of Utopia (trilogy of plays) (material)
<img width="349" alt="the-coast-of-utopia-material" src="https://user-images.githubusercontent.com/10484515/178113324-05627d8a-c3e1-46c6-98ea-6fd9e4809aa1.png">

---

#### Voyage (play) (material)
<img width="499" alt="the-coast-of-utopia-voyage-material" src="https://user-images.githubusercontent.com/10484515/178113358-cfcaf3b7-7c48-4e10-b3da-fe6bec2ec3a1.png">

---

#### Tom Stoppard (person)
<img width="431" alt="tom-stoppard-person" src="https://user-images.githubusercontent.com/10484515/178113371-5d01490b-933b-454b-b02a-af59f5b4698d.png">

---

#### Michael Bakunin (chatracter)
<img width="419" alt="michael-bakunin-character" src="https://user-images.githubusercontent.com/10484515/178113403-bc233573-058a-4499-b6df-886636186312.png">

---

#### Voyage at Olivier Theatre (production)
<img width="385" alt="the-coast-of-utopia-voyage-olivier-production" src="https://user-images.githubusercontent.com/10484515/178113439-703076d3-7e69-4a69-aaa7-3938bada1807.png">

---

#### Materials list
<img width="877" alt="materials-list" src="https://user-images.githubusercontent.com/10484515/178114447-3c76c980-4ede-4879-90b4-367733bcd2b9.png">

---

## Test examples

### `award-ceremonies-nominated-sub-materials.test.js`

#### Wordsmith Award 2010 (award ceremony)
<img width="931" alt="wordsmith-award-2010-award-ceremony" src="https://user-images.githubusercontent.com/10484515/178113526-f2dd7ce5-ecf5-4bd6-9b7d-18995558eac2.png">

---

#### Playwriting Prize 2009 (award ceremony)
<img width="925" alt="playwriting-prize-2009-award-ceremony" src="https://user-images.githubusercontent.com/10484515/178113539-f620b89e-5920-4ed7-9868-824d10aa6916.png">

---

#### John Doe (person): credit for directly nominated material
<img width="927" alt="john-doe-person" src="https://user-images.githubusercontent.com/10484515/178113556-730d4f7a-17a5-400e-86b1-833b5854a311.png">

---

#### Playwrights Ltd (company): credit for directly nominated material
<img width="922" alt="playwrights-ltd-company" src="https://user-images.githubusercontent.com/10484515/178113578-dd645057-4199-481d-a79f-b57e28022510.png">

---

#### Sub-Plugh (play, 1899) (material): subsequent versions have nominations
<img width="889" alt="sub-plugh-original-version-material" src="https://user-images.githubusercontent.com/10484515/178113625-eb076941-ecda-4c36-81ca-df8d26903768.png">

---

#### Sur-Plugh (play, 1899) (material): subsequent versions have nominations
<img width="907" alt="sur-plugh-original-version-material" src="https://user-images.githubusercontent.com/10484515/178113604-67348239-8600-4437-9898-c8e3021febe3.png">

---

#### Francis Flob (person): subsequent versions of their work have nominations
<img width="910" alt="francis-flob-person" src="https://user-images.githubusercontent.com/10484515/178113641-9456b2a0-4c87-4058-a763-25ac0f5c2b0e.png">

---

#### Curtain Up Ltd (company): subsequent versions of their work have nominations
<img width="908" alt="curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/178113655-c39dfbc4-500a-481c-83d5-a4708b7a1635.png">

---

#### Sub-Waldo (novel, 1974) (material): materials that used it as source material have nominations
<img width="924" alt="sub-waldo-material" src="https://user-images.githubusercontent.com/10484515/178113683-7b2330a7-6c7a-4b0e-8bff-588e87d9fcc5.png">

---

#### Sur-Waldo (trilogy of novels, 1974) (material): materials that used it as source material have nominations
<img width="937" alt="sur-waldo-material" src="https://user-images.githubusercontent.com/10484515/178120588-6dccedc1-b960-47bc-9925-a3533644e498.png">

---

#### Jane Roe (person): materials that used their (specific) work as source material have nominations
<img width="938" alt="jane-roe-person" src="https://user-images.githubusercontent.com/10484515/178113704-df076c1d-39f8-436b-b3be-3212a6cc94f6.png">

---

#### Fictioneers Ltd (company): materials that used their (specific) work as source material have nominations
<img width="947" alt="fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/178113710-a0e2a595-f33d-460f-a251-a67ce928ba25.png">

---

#### Talyse Tata (person): materials to which they have granted rights have nominations
<img width="932" alt="talyse-tata-person" src="https://user-images.githubusercontent.com/10484515/178113716-57603267-4a3e-4732-9436-84b450d0a28c.png">

---

#### Cinerights Ltd (company): materials to which they granted rights have nominations
<img width="937" alt="cinerights-ltd-company" src="https://user-images.githubusercontent.com/10484515/178113723-ba36a088-37dd-44a3-beae-b1f16e8f43c9.png">

---

### `award-ceremonies-with-sub-materials.test.js`

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="916" alt="laurence-olivier-awards-2020-award-ceremony" src="https://user-images.githubusercontent.com/10484515/178113782-6fc9cd83-fa3e-4d16-be8d-cd024c38b56b.png">

---

#### Evening Standard Theatre Awards 2019 (award ceremony)
<img width="920" alt="evening-standard-theatre-awards-2019" src="https://user-images.githubusercontent.com/10484515/178113792-cbd8ab68-6bd5-414a-a7b9-dd55d4ffc6a0.png">

---

#### Conor Corge (person)
<img width="926" alt="conor-corge-person" src="https://user-images.githubusercontent.com/10484515/178113800-57b3bdcc-6dde-4c96-bbbd-28f1b703395e.png">

---

#### Stagecraft Ltd (company)
<img width="923" alt="stagecraft-ltd-company" src="https://user-images.githubusercontent.com/10484515/178113809-549f081c-7bfe-49f4-b260-058fef242fcf.png">

---

#### Ferdinand Foo (person)
<img width="931" alt="ferdinand-foo-person" src="https://user-images.githubusercontent.com/10484515/178113823-c6b44112-e6ce-45ca-907a-5d962afc050e.png">

---

#### Sub-Wibble at Old Vic Theatre (production)
<img width="820" alt="sub-wibble-old-vic-production" src="https://user-images.githubusercontent.com/10484515/178113838-ef9565ba-801b-4ddf-ba5c-d13feb12b880.png">

---

#### Sur-Wibble at Old Vic Theatre (production)
<img width="748" alt="sur-wibble-old-vic-production" src="https://user-images.githubusercontent.com/10484515/178113847-9c067e62-8598-49cc-b71f-77b2ea4f102b.png">

---

#### Sub-Wibble (play) (material)
<img width="905" alt="sub-wibble-material" src="https://user-images.githubusercontent.com/10484515/178113852-66bceea5-4ea9-49c8-b849-9dbc83be663f.png">

---

#### Sur-Wibble (trilogy of plays) (material)
<img width="918" alt="sur-wibble-material" src="https://user-images.githubusercontent.com/10484515/178113860-1a811f41-110d-4b37-8cd8-5da1d41b55c4.png">

---

### `material-with-multi-sub-material-versions.test.js`

#### Agamemnon (original version) (material)
<img width="607" alt="agamemnon-original-version-material" src="https://user-images.githubusercontent.com/10484515/178113997-ac8031d7-d34c-47cb-9d41-f6c64029f4ba.png">

---

#### Agamemnon (subsequent version) (material)
<img width="785" alt="agamemnon-subsequent-version-material" src="https://user-images.githubusercontent.com/10484515/178114009-b44cd417-cf53-4186-94db-9aaa637d26e3.png">

---

#### Aeschylus (person)
<img width="812" alt="aeschylus-person" src="https://user-images.githubusercontent.com/10484515/178114023-d729d808-4d63-450e-9873-bbf12d8428bb.png">

---

#### The Fathers of Tragedy (company)
<img width="813" alt="the-fathers-of-tragedy-company" src="https://user-images.githubusercontent.com/10484515/178114042-76ab5a18-bfb9-4493-95dd-a67223950144.png">

---

### `material-with-source-sub-material.test.js`

#### Bring Up the Bodies (novel) (material)
<img width="916" alt="bring-up-the-bodies-novel-material" src="https://user-images.githubusercontent.com/10484515/178114081-8a2a9d8b-5aec-48f5-b8e8-6e0b5d98eaf0.png">

---

#### Bring Up the Bodies (play) (material)
<img width="928" alt="bring-up-the-bodies-play-material" src="https://user-images.githubusercontent.com/10484515/178114088-9ccf38e0-f078-410b-b848-6ddf62b4fa47.png">

---

#### Hilary Mantel (person)
<img width="924" alt="hilary-mantel-person" src="https://user-images.githubusercontent.com/10484515/178114117-23c389da-fe44-41f6-adbb-5109b7450e9d.png">

---

#### Mike Poulton (person)
<img width="926" alt="mike-poulton-person" src="https://user-images.githubusercontent.com/10484515/178114126-a01ccf7e-ffed-4dbc-8fb0-e6e7bb660392.png">

---

#### The Mantel Group (company)
<img width="919" alt="the-mantel-group-company" src="https://user-images.githubusercontent.com/10484515/178114135-2fd314b1-1d19-40e0-a321-88aaf1e8ee3d.png">

---

#### Royal Shakespeare Company (company)
<img width="926" alt="royal-shakespeare-company-company" src="https://user-images.githubusercontent.com/10484515/178114142-3879ba87-6637-4a06-a850-286487ab3893.png">

---

#### Bring Up the Bodies at Swan Theatre (production)
<img width="923" alt="bring-up-the-bodies-swan-theatre-production" src="https://user-images.githubusercontent.com/10484515/178114152-621ca666-7dbb-452f-b5a6-91e2c6109437.png">

---

#### Thomas Cromwell (character)
<img width="920" alt="thomas-cromwell-character" src="https://user-images.githubusercontent.com/10484515/178114162-a38b3968-c781-444a-bc88-9f9c35be61f3.png">

---

#### Materials list
<img width="942" alt="materials-list" src="https://user-images.githubusercontent.com/10484515/178114176-4d01c4e6-1d8e-4fae-a9f7-6a568b471d43.png">

---

### `material-with-sub-materials.test.js`

#### The Coast of Utopia (material with sub-materials)
<img width="460" alt="the-coast-of-utopia-material" src="https://user-images.githubusercontent.com/10484515/178114226-0474c00e-64ef-4075-a2c0-48200df9f113.png">

---

#### Voyage (material with sur-material)
<img width="544" alt="voyage-material" src="https://user-images.githubusercontent.com/10484515/178114237-c47f2521-4f7f-45bf-94fa-5288d56db920.png">

---

#### Alexander Herzen (character)
<img width="559" alt="alexander-herzen-character" src="https://user-images.githubusercontent.com/10484515/178114250-5cef16d0-92d4-48b0-a35c-0736651ef61d.png">

---

#### Ivan Turgenev (character)
<img width="552" alt="ivan-turgenev-character" src="https://user-images.githubusercontent.com/10484515/178114255-4404ce24-d40b-4d94-b7d2-ee9e67770041.png">

---

#### Voyage at Olivier Theatre (production)
<img width="517" alt="voyage-olivier-production" src="https://user-images.githubusercontent.com/10484515/178114265-7d2e59b6-f2ff-48a7-a3d9-465038c70041.png">

---

#### The Coast of Utopia at Olivier Theatre (production)
<img width="520" alt="the-coats-of-utopia-olivier-production" src="https://user-images.githubusercontent.com/10484515/178114271-7cb428ca-2004-41db-bdaf-e532a9f5dbed.png">

---

#### Tom Stoppard (person)
<img width="559" alt="tom-stoppard-person" src="https://user-images.githubusercontent.com/10484515/178114281-11c57948-d252-4a5c-b641-c3ed98fb26b5.png">

---

#### The Sträussler Group (company)
<img width="557" alt="the-sträussler-group-company" src="https://user-images.githubusercontent.com/10484515/178114294-12043c47-e32f-4c1b-8102-b26630cc0ad7.png">

---

#### Materials list
<img width="551" alt="materials-list" src="https://user-images.githubusercontent.com/10484515/178114306-35ea46f7-3fa8-4f29-9937-5acfae5c07c9.png">

---

### `sub-material-with-rights-grantor.test.js`

#### C S Lewis Society (company)
<img width="927" alt="c-s-lewis-society-company" src="https://user-images.githubusercontent.com/10484515/178114348-35577fe2-910a-4208-8a4b-6925f455193d.png">

---

#### Sarah Selden (person)
<img width="919" alt="sarah-snelden-person" src="https://user-images.githubusercontent.com/10484515/178114366-289646f7-0f58-44bb-bbdc-7b7870519577.png">