### PR TITLE
Apply recommended react-router-dom v5.1 style

### DIFF
--- a/src/react/App.jsx
+++ b/src/react/App.jsx
@@ -1,45 +1,39 @@
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Route, Switch, useLocation } from 'react-router-dom';
 
 import routes from './routes';
 import { FetchDataOnMountWrapper } from './utils';
 
-class App extends React.Component {
+const App = () => {
 
-	render () {
+	const location = useLocation();
 
-		return (
-			<Switch>
-				{
-					routes.map((route, index) =>
+	return (
+		<Switch>
+			{
+				routes.map((route, index) => {
+					const RouteComponent = route.component;
+
+					return (
 						<Route
 							key={index}
 							path={route.path}
 							exact={route.exact}
-							render={
-								props => {
-									const RouteComponent = route.component;
-									return (
-										<FetchDataOnMountWrapper
-											{...props}
-											documentTitle={route.documentTitle}
-											fetchData={route.fetchData}
-											key={props.match.params.uuid}
-										>
-											<RouteComponent />
-										</FetchDataOnMountWrapper>
-									);
-								}
-							}
-						/>
+						>
+							<FetchDataOnMountWrapper
+								documentTitle={route.documentTitle}
+								fetchData={route.fetchData}
+								key={location.key}
+							>
+								<RouteComponent />
+							</FetchDataOnMountWrapper>
+						</Route>
+					);
+				})
+			}
+		</Switch>
+	);
 
-					)
-				}
-			</Switch>
-		);
-
-	}
-
-}
+};
 
 export default App;

--- a/src/react/pages/instances/Award.jsx
+++ b/src/react/pages/instances/Award.jsx
@@ -5,33 +5,29 @@ import { connect } from 'react-redux';
 import { InstanceFacet, List } from '../../components';
 import { InstanceWrapper } from '../../utils';
 
-class Award extends React.Component {
+const Award = props => {
 
-	render () {
+	const { award } = props;
 
-		const { award } = this.props;
+	const ceremonies = award.get('ceremonies');
 
-		const ceremonies = award.get('ceremonies');
+	return (
+		<InstanceWrapper instance={award}>
 
-		return (
-			<InstanceWrapper instance={award}>
+			{
+				ceremonies?.size > 0 && (
+					<InstanceFacet labelText='Ceremonies'>
 
-				{
-					ceremonies?.size > 0 && (
-						<InstanceFacet labelText='Ceremonies'>
+						<List instances={ceremonies} />
 
-							<List instances={ceremonies} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+		</InstanceWrapper>
+	);
 
-			</InstanceWrapper>
-		);
-
-	}
-
-}
+};
 
 Award.propTypes = {
 	award: ImmutablePropTypes.map.isRequired

--- a/src/react/pages/instances/AwardCeremony.jsx
+++ b/src/react/pages/instances/AwardCeremony.jsx
@@ -5,101 +5,97 @@ import { connect } from 'react-redux';
 import { Entities, InstanceFacet, InstanceLink, Materials, Productions } from '../../components';
 import { InstanceWrapper } from '../../utils';
 
-class AwardCeremony extends React.Component {
+const AwardCeremony = props => {
 
-	render () {
+	const { awardCeremony } = props;
 
-		const { awardCeremony } = this.props;
+	const award = awardCeremony.get('award');
+	const categories = awardCeremony.get('categories');
 
-		const award = awardCeremony.get('award');
-		const categories = awardCeremony.get('categories');
+	return (
+		<InstanceWrapper instance={awardCeremony}>
 
-		return (
-			<InstanceWrapper instance={awardCeremony}>
+			{
+				award && (
+					<InstanceFacet labelText='Award'>
 
-				{
-					award && (
-						<InstanceFacet labelText='Award'>
+						<InstanceLink instance={award} />
 
-							<InstanceLink instance={award} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				categories?.size > 0 && (
+					<InstanceFacet labelText='Categories'>
 
-				{
-					categories?.size > 0 && (
-						<InstanceFacet labelText='Categories'>
+						{
+							categories.map((category, index) =>
+								<React.Fragment key={index}>
+									{ category.get('name') }
 
-							{
-								categories.map((category, index) =>
-									<React.Fragment key={index}>
-										{ category.get('name') }
+									<ul className="list">
 
-										<ul className="list">
-
-											{
-												category.get('nominations').map((nomination, index) =>
-													<li key={index}>
-														<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
-															{`${nomination.get('type')}: `}
-														</span>
-
-														{
-															nomination.get('entities').size > 0 && (
-																<Entities entities={nomination.get('entities')} />
-															)
-														}
-
-														{
-															nomination.get('entities').size > 0 &&
-															(
-																nomination.get('productions').size > 0 ||
-																nomination.get('materials').size > 0
-															) && (
-																<React.Fragment>{' for '}</React.Fragment>
-															)
-														}
-
-														{
-															nomination.get('productions').size > 0 && (
-																<Productions
-																	productions={nomination.get('productions')}
-																/>
-															)
-														}
+										{
+											category.get('nominations').map((nomination, index) =>
+												<li key={index}>
+													<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+														{`${nomination.get('type')}: `}
+													</span>
 
 													{
-														nomination.get('productions').size > 0 &&
-														nomination.get('materials').size > 0 && (
-															<React.Fragment>{'; '}</React.Fragment>
+														nomination.get('entities').size > 0 && (
+															<Entities entities={nomination.get('entities')} />
 														)
 													}
 
-														{
-															nomination.get('materials').size > 0 && (
-																<Materials materials={nomination.get('materials')} />
-															)
-														}
-													</li>
-												)
-											}
+													{
+														nomination.get('entities').size > 0 &&
+														(
+															nomination.get('productions').size > 0 ||
+															nomination.get('materials').size > 0
+														) && (
+															<React.Fragment>{' for '}</React.Fragment>
+														)
+													}
 
-										</ul>
-									</React.Fragment>
-								)
-							}
+													{
+														nomination.get('productions').size > 0 && (
+															<Productions
+																productions={nomination.get('productions')}
+															/>
+														)
+													}
 
-						</InstanceFacet>
-					)
-				}
+												{
+													nomination.get('productions').size > 0 &&
+													nomination.get('materials').size > 0 && (
+														<React.Fragment>{'; '}</React.Fragment>
+													)
+												}
 
-			</InstanceWrapper>
-		);
+													{
+														nomination.get('materials').size > 0 && (
+															<Materials materials={nomination.get('materials')} />
+														)
+													}
+												</li>
+											)
+										}
 
-	}
+									</ul>
+								</React.Fragment>
+							)
+						}
 
-}
+					</InstanceFacet>
+				)
+			}
+
+		</InstanceWrapper>
+	);
+
+};
 
 AwardCeremony.propTypes = {
 	awardCeremony: ImmutablePropTypes.map.isRequired

--- a/src/react/pages/instances/Character.jsx
+++ b/src/react/pages/instances/Character.jsx
@@ -5,66 +5,62 @@ import { connect } from 'react-redux';
 import { InstanceFacet, JoinedRoles, List } from '../../components';
 import { InstanceWrapper } from '../../utils';
 
-class Character extends React.Component {
+const Character = props => {
 
-	render () {
+	const { character } = props;
 
-		const { character } = this.props;
+	const variantNamedDepictions = character.get('variantNamedDepictions');
+	const materials = character.get('materials');
+	const variantNamedPortrayals = character.get('variantNamedPortrayals');
+	const productions = character.get('productions');
 
-		const variantNamedDepictions = character.get('variantNamedDepictions');
-		const materials = character.get('materials');
-		const variantNamedPortrayals = character.get('variantNamedPortrayals');
-		const productions = character.get('productions');
+	return (
+		<InstanceWrapper instance={character}>
 
-		return (
-			<InstanceWrapper instance={character}>
+			{
+				variantNamedDepictions?.size > 0 && (
+					<InstanceFacet labelText='Variant named depictions'>
 
-				{
-					variantNamedDepictions?.size > 0 && (
-						<InstanceFacet labelText='Variant named depictions'>
+						<JoinedRoles instances={variantNamedDepictions} />
 
-							<JoinedRoles instances={variantNamedDepictions} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				materials?.size > 0 && (
+					<InstanceFacet labelText='Materials'>
 
-				{
-					materials?.size > 0 && (
-						<InstanceFacet labelText='Materials'>
+						<List instances={materials} />
 
-							<List instances={materials} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				variantNamedPortrayals?.size > 0 && (
+					<InstanceFacet labelText='Variant named portrayals'>
 
-				{
-					variantNamedPortrayals?.size > 0 && (
-						<InstanceFacet labelText='Variant named portrayals'>
+						<JoinedRoles instances={variantNamedPortrayals} />
 
-							<JoinedRoles instances={variantNamedPortrayals} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				productions?.size > 0 && (
+					<InstanceFacet labelText='Productions'>
 
-				{
-					productions?.size > 0 && (
-						<InstanceFacet labelText='Productions'>
+						<List instances={productions} />
 
-							<List instances={productions} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+		</InstanceWrapper>
+	);
 
-			</InstanceWrapper>
-		);
-
-	}
-
-}
+};
 
 Character.propTypes = {
 	character: ImmutablePropTypes.map.isRequired

--- a/src/react/pages/instances/Company.jsx
+++ b/src/react/pages/instances/Company.jsx
@@ -14,516 +14,512 @@ import {
 } from '../../components';
 import { InstanceWrapper } from '../../utils';
 
-class Company extends React.Component {
+const Company = props => {
 
-	render () {
+	const { company } = props;
 
-		const { company } = this.props;
+	const materials = company.get('materials');
+	const subsequentVersionMaterials = company.get('subsequentVersionMaterials');
+	const sourcingMaterials = company.get('sourcingMaterials');
+	const rightsGrantorMaterials = company.get('rightsGrantorMaterials');
+	const producerProductions = company.get('producerProductions');
+	const creativeProductions = company.get('creativeProductions');
+	const crewProductions = company.get('crewProductions');
+	const awards = company.get('awards');
+	const subsequentVersionMaterialAwards = company.get('subsequentVersionMaterialAwards');
+	const sourcingMaterialAwards = company.get('sourcingMaterialAwards');
+	const rightsGrantorMaterialAwards = company.get('rightsGrantorMaterialAwards');
 
-		const materials = company.get('materials');
-		const subsequentVersionMaterials = company.get('subsequentVersionMaterials');
-		const sourcingMaterials = company.get('sourcingMaterials');
-		const rightsGrantorMaterials = company.get('rightsGrantorMaterials');
-		const producerProductions = company.get('producerProductions');
-		const creativeProductions = company.get('creativeProductions');
-		const crewProductions = company.get('crewProductions');
-		const awards = company.get('awards');
-		const subsequentVersionMaterialAwards = company.get('subsequentVersionMaterialAwards');
-		const sourcingMaterialAwards = company.get('sourcingMaterialAwards');
-		const rightsGrantorMaterialAwards = company.get('rightsGrantorMaterialAwards');
+	return (
+		<InstanceWrapper instance={company}>
 
-		return (
-			<InstanceWrapper instance={company}>
+			{
+				materials?.size > 0 && (
+					<InstanceFacet labelText='Materials'>
 
-				{
-					materials?.size > 0 && (
-						<InstanceFacet labelText='Materials'>
+						<List instances={materials} />
 
-							<List instances={materials} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				subsequentVersionMaterials?.size > 0 && (
+					<InstanceFacet labelText='Subsequent versions of their materials'>
 
-				{
-					subsequentVersionMaterials?.size > 0 && (
-						<InstanceFacet labelText='Subsequent versions of their materials'>
+						<List instances={subsequentVersionMaterials} />
 
-							<List instances={subsequentVersionMaterials} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				sourcingMaterials?.size > 0 && (
+					<InstanceFacet labelText='Materials as source material writer'>
 
-				{
-					sourcingMaterials?.size > 0 && (
-						<InstanceFacet labelText='Materials as source material writer'>
+						<List instances={sourcingMaterials} />
 
-							<List instances={sourcingMaterials} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				rightsGrantorMaterials?.size > 0 && (
+					<InstanceFacet labelText='Materials as rights grantor'>
 
-				{
-					rightsGrantorMaterials?.size > 0 && (
-						<InstanceFacet labelText='Materials as rights grantor'>
+						<List instances={rightsGrantorMaterials} />
 
-							<List instances={rightsGrantorMaterials} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				producerProductions?.size > 0 && (
+					<InstanceFacet labelText='Productions as producer'>
 
-				{
-					producerProductions?.size > 0 && (
-						<InstanceFacet labelText='Productions as producer'>
+						<List instances={producerProductions} />
 
-							<List instances={producerProductions} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				creativeProductions?.size > 0 && (
+					<InstanceFacet labelText='Productions as creative team member'>
 
-				{
-					creativeProductions?.size > 0 && (
-						<InstanceFacet labelText='Productions as creative team member'>
+						<List instances={creativeProductions} />
 
-							<List instances={creativeProductions} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				crewProductions?.size > 0 && (
+					<InstanceFacet labelText='Productions as crew member'>
 
-				{
-					crewProductions?.size > 0 && (
-						<InstanceFacet labelText='Productions as crew member'>
+						<List instances={crewProductions} />
 
-							<List instances={crewProductions} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				awards?.size > 0 && (
+					<InstanceFacet labelText='Awards'>
 
-				{
-					awards?.size > 0 && (
-						<InstanceFacet labelText='Awards'>
+						{
+							awards.map((award, index) =>
+								<React.Fragment key={index}>
+									<InstanceLink instance={award} />
 
-							{
-								awards.map((award, index) =>
-									<React.Fragment key={index}>
-										<InstanceLink instance={award} />
+									<ul className="list">
 
-										<ul className="list">
+										{
+											award.get('ceremonies').map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
 
-											{
-												award.get('ceremonies').map((ceremony, index) =>
-													<li key={index}>
-														<InstanceLink instance={ceremony} />{': '}
+													{
+														ceremony.get('categories')
+															.map((category, index) =>
+																<React.Fragment key={index}>
+																	{ category.get('name') }{': '}
 
-														{
-															ceremony.get('categories')
-																.map((category, index) =>
-																	<React.Fragment key={index}>
-																		{ category.get('name') }{': '}
+																	{
+																		category.get('nominations')
+																			.map((nomination, index) =>
+																				<React.Fragment key={index}>
+																					<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																						{nomination.get('type')}
+																					</span>
 
-																		{
-																			category.get('nominations')
-																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
-																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
-																							{nomination.get('type')}
-																						</span>
+																					{
+																						nomination.get('members')?.size > 0 && (
+																							<AppendedMembers
+																								members={nomination.get('members')}
+																							/>
+																						)
+																					}
 
-																						{
-																							nomination.get('members')?.size > 0 && (
-																								<AppendedMembers
-																									members={nomination.get('members')}
+																					{
+																						nomination.get('coEntities').size > 0 && (
+																							<AppendedCoEntities
+																								coEntities={nomination.get('coEntities')}
+																							/>
+																						)
+																					}
+
+																					{
+																						nomination.get('productions').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Productions
+																									productions={nomination.get('productions')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('coEntities').size > 0 && (
-																								<AppendedCoEntities
-																									coEntities={nomination.get('coEntities')}
+																					{
+																						nomination.get('productions').size > 0 &&
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>{';'}</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('materials')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
+																				</React.Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</React.Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
 
-																						{
-																							nomination.get('productions').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Productions
-																										productions={nomination.get('productions')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
+									</ul>
+								</React.Fragment>
+							)
+						}
 
-																						{
-																							nomination.get('productions').size > 0 &&
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>{';'}</React.Fragment>
-																							)
-																						}
+					</InstanceFacet>
+				)
+			}
 
-																						{
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('materials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-																					</React.Fragment>
-																				)
-																				.reduce((prev, curr) => [prev, ', ', curr])
-																		}
-																	</React.Fragment>
-																)
-																.reduce((prev, curr) => [prev, '; ', curr])
-														}
-													</li>
-												)
-											}
+			{
+				subsequentVersionMaterialAwards?.size > 0 && (
+					<InstanceFacet labelText='Awards for subsequent versions of their material'>
 
-										</ul>
-									</React.Fragment>
-								)
-							}
+						{
+							subsequentVersionMaterialAwards.map((subsequentVersionMaterialAward, index) =>
+								<React.Fragment key={index}>
+									<InstanceLink instance={subsequentVersionMaterialAward} />
 
-						</InstanceFacet>
-					)
-				}
+									<ul className="list">
 
-				{
-					subsequentVersionMaterialAwards?.size > 0 && (
-						<InstanceFacet labelText='Awards for subsequent versions of their material'>
+										{
+											subsequentVersionMaterialAward.get('ceremonies').map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
 
-							{
-								subsequentVersionMaterialAwards.map((subsequentVersionMaterialAward, index) =>
-									<React.Fragment key={index}>
-										<InstanceLink instance={subsequentVersionMaterialAward} />
+													{
+														ceremony.get('categories')
+															.map((category, index) =>
+																<React.Fragment key={index}>
+																	{ category.get('name') }{': '}
 
-										<ul className="list">
+																	{
+																		category.get('nominations')
+																			.map((nomination, index) =>
+																				<React.Fragment key={index}>
+																					<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																						{nomination.get('type')}
+																					</span>
 
-											{
-												subsequentVersionMaterialAward.get('ceremonies').map((ceremony, index) =>
-													<li key={index}>
-														<InstanceLink instance={ceremony} />{': '}
-
-														{
-															ceremony.get('categories')
-																.map((category, index) =>
-																	<React.Fragment key={index}>
-																		{ category.get('name') }{': '}
-
-																		{
-																			category.get('nominations')
-																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
-																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
-																							{nomination.get('type')}
-																						</span>
-
-																						{
-																							nomination.get('subsequentVersionMaterials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{': '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('subsequentVersionMaterials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('members')?.size > 0 && (
-																								<AppendedMembers
-																									members={nomination.get('members')}
+																					{
+																						nomination.get('subsequentVersionMaterials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{': '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('subsequentVersionMaterials')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('entities').size > 0 && (
-																								<AppendedEntities
-																									entities={nomination.get('entities')}
+																					{
+																						nomination.get('members')?.size > 0 && (
+																							<AppendedMembers
+																								members={nomination.get('members')}
+																							/>
+																						)
+																					}
+
+																					{
+																						nomination.get('entities').size > 0 && (
+																							<AppendedEntities
+																								entities={nomination.get('entities')}
+																							/>
+																						)
+																					}
+
+																					{
+																						nomination.get('productions').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Productions
+																									productions={nomination.get('productions')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('productions').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Productions
-																										productions={nomination.get('productions')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
+																					{
+																						nomination.get('productions').size > 0 &&
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>{';'}</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('productions').size > 0 &&
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>{';'}</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('materials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-																					</React.Fragment>
-																				)
-																				.reduce((prev, curr) => [prev, ', ', curr])
-																		}
-																	</React.Fragment>
-																)
-																.reduce((prev, curr) => [prev, '; ', curr])
-														}
-													</li>
-												)
-											}
-
-										</ul>
-									</React.Fragment>
-								)
-							}
-
-						</InstanceFacet>
-					)
-				}
-
-				{
-					sourcingMaterialAwards?.size > 0 && (
-						<InstanceFacet labelText='Awards for materials as source material writer'>
-
-							{
-								sourcingMaterialAwards.map((sourcingMaterialAward, index) =>
-									<React.Fragment key={index}>
-										<InstanceLink instance={sourcingMaterialAward} />
-
-										<ul className="list">
-
-											{
-												sourcingMaterialAward.get('ceremonies').map((ceremony, index) =>
-													<li key={index}>
-														<InstanceLink instance={ceremony} />{': '}
-
-														{
-															ceremony.get('categories')
-																.map((category, index) =>
-																	<React.Fragment key={index}>
-																		{ category.get('name') }{': '}
-
-																		{
-																			category.get('nominations')
-																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
-																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
-																							{nomination.get('type')}
-																						</span>
-
-																						{
-																							nomination.get('sourcingMaterials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{': '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('sourcingMaterials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('members')?.size > 0 && (
-																								<AppendedMembers
-																									members={nomination.get('members')}
+																					{
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('materials')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
+																				</React.Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</React.Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
 
-																						{
-																							nomination.get('entities').size > 0 && (
-																								<AppendedEntities
-																									entities={nomination.get('entities')}
+									</ul>
+								</React.Fragment>
+							)
+						}
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				sourcingMaterialAwards?.size > 0 && (
+					<InstanceFacet labelText='Awards for materials as source material writer'>
+
+						{
+							sourcingMaterialAwards.map((sourcingMaterialAward, index) =>
+								<React.Fragment key={index}>
+									<InstanceLink instance={sourcingMaterialAward} />
+
+									<ul className="list">
+
+										{
+											sourcingMaterialAward.get('ceremonies').map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
+
+													{
+														ceremony.get('categories')
+															.map((category, index) =>
+																<React.Fragment key={index}>
+																	{ category.get('name') }{': '}
+
+																	{
+																		category.get('nominations')
+																			.map((nomination, index) =>
+																				<React.Fragment key={index}>
+																					<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																						{nomination.get('type')}
+																					</span>
+
+																					{
+																						nomination.get('sourcingMaterials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{': '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('sourcingMaterials')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('productions').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Productions
-																										productions={nomination.get('productions')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
+																					{
+																						nomination.get('members')?.size > 0 && (
+																							<AppendedMembers
+																								members={nomination.get('members')}
+																							/>
+																						)
+																					}
 
-																						{
-																							nomination.get('productions').size > 0 &&
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>{';'}</React.Fragment>
-																							)
-																						}
+																					{
+																						nomination.get('entities').size > 0 && (
+																							<AppendedEntities
+																								entities={nomination.get('entities')}
+																							/>
+																						)
+																					}
 
-																						{
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('materials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-																					</React.Fragment>
-																				)
-																				.reduce((prev, curr) => [prev, ', ', curr])
-																		}
-																	</React.Fragment>
-																)
-																.reduce((prev, curr) => [prev, '; ', curr])
-														}
-													</li>
-												)
-											}
-
-										</ul>
-									</React.Fragment>
-								)
-							}
-
-						</InstanceFacet>
-					)
-				}
-
-				{
-					rightsGrantorMaterialAwards?.size > 0 && (
-						<InstanceFacet labelText='Awards for materials as rights grantor'>
-
-							{
-								rightsGrantorMaterialAwards.map((rightsGrantorMaterialAward, index) =>
-									<React.Fragment key={index}>
-										<InstanceLink instance={rightsGrantorMaterialAward} />
-
-										<ul className="list">
-
-											{
-												rightsGrantorMaterialAward.get('ceremonies').map((ceremony, index) =>
-													<li key={index}>
-														<InstanceLink instance={ceremony} />{': '}
-
-														{
-															ceremony.get('categories')
-																.map((category, index) =>
-																	<React.Fragment key={index}>
-																		{ category.get('name') }{': '}
-
-																		{
-																			category.get('nominations')
-																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
-																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
-																							{nomination.get('type')}
-																						</span>
-
-																						{
-																							nomination.get('rightsGrantorMaterials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{': '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('rightsGrantorMaterials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('members')?.size > 0 && (
-																								<AppendedMembers
-																									members={nomination.get('members')}
+																					{
+																						nomination.get('productions').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Productions
+																									productions={nomination.get('productions')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('entities').size > 0 && (
-																								<AppendedEntities
-																									entities={nomination.get('entities')}
+																					{
+																						nomination.get('productions').size > 0 &&
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>{';'}</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('materials')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
+																				</React.Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</React.Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
 
-																						{
-																							nomination.get('productions').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Productions
-																										productions={nomination.get('productions')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
+									</ul>
+								</React.Fragment>
+							)
+						}
 
-																						{
-																							nomination.get('productions').size > 0 &&
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>{';'}</React.Fragment>
-																							)
-																						}
+					</InstanceFacet>
+				)
+			}
 
-																						{
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('materials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-																					</React.Fragment>
-																				)
-																				.reduce((prev, curr) => [prev, ', ', curr])
-																		}
-																	</React.Fragment>
-																)
-																.reduce((prev, curr) => [prev, '; ', curr])
-														}
-													</li>
-												)
-											}
+			{
+				rightsGrantorMaterialAwards?.size > 0 && (
+					<InstanceFacet labelText='Awards for materials as rights grantor'>
 
-										</ul>
-									</React.Fragment>
-								)
-							}
+						{
+							rightsGrantorMaterialAwards.map((rightsGrantorMaterialAward, index) =>
+								<React.Fragment key={index}>
+									<InstanceLink instance={rightsGrantorMaterialAward} />
 
-						</InstanceFacet>
-					)
-				}
+									<ul className="list">
 
-			</InstanceWrapper>
-		);
+										{
+											rightsGrantorMaterialAward.get('ceremonies').map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
 
-	}
+													{
+														ceremony.get('categories')
+															.map((category, index) =>
+																<React.Fragment key={index}>
+																	{ category.get('name') }{': '}
 
-}
+																	{
+																		category.get('nominations')
+																			.map((nomination, index) =>
+																				<React.Fragment key={index}>
+																					<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																						{nomination.get('type')}
+																					</span>
+
+																					{
+																						nomination.get('rightsGrantorMaterials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{': '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('rightsGrantorMaterials')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('members')?.size > 0 && (
+																							<AppendedMembers
+																								members={nomination.get('members')}
+																							/>
+																						)
+																					}
+
+																					{
+																						nomination.get('entities').size > 0 && (
+																							<AppendedEntities
+																								entities={nomination.get('entities')}
+																							/>
+																						)
+																					}
+
+																					{
+																						nomination.get('productions').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Productions
+																									productions={nomination.get('productions')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('productions').size > 0 &&
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>{';'}</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('materials')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+																				</React.Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</React.Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
+
+									</ul>
+								</React.Fragment>
+							)
+						}
+
+					</InstanceFacet>
+				)
+			}
+
+		</InstanceWrapper>
+	);
+
+};
 
 Company.propTypes = {
 	company: ImmutablePropTypes.map.isRequired

--- a/src/react/pages/instances/Material.jsx
+++ b/src/react/pages/instances/Material.jsx
@@ -16,535 +16,531 @@ import {
 } from '../../components';
 import { InstanceWrapper } from '../../utils';
 
-class Material extends React.Component {
+const Material = props => {
 
-	render () {
+	const { material } = props;
 
-		const { material } = this.props;
+	const format = material.get('format');
+	const year = material.get('year');
+	const writingCredits = material.get('writingCredits');
+	const surMaterial = material.get('surMaterial');
+	const subMaterials = material.get('subMaterials');
+	const characterGroups = material.get('characterGroups');
+	const originalVersionMaterial = material.get('originalVersionMaterial');
+	const subsequentVersionMaterials = material.get('subsequentVersionMaterials');
+	const productions = material.get('productions');
+	const sourcingMaterials = material.get('sourcingMaterials');
+	const sourcingMaterialProductions = material.get('sourcingMaterialProductions');
+	const awards = material.get('awards');
+	const subsequentVersionMaterialAwards = material.get('subsequentVersionMaterialAwards');
+	const sourcingMaterialAwards = material.get('sourcingMaterialAwards');
 
-		const format = material.get('format');
-		const year = material.get('year');
-		const writingCredits = material.get('writingCredits');
-		const surMaterial = material.get('surMaterial');
-		const subMaterials = material.get('subMaterials');
-		const characterGroups = material.get('characterGroups');
-		const originalVersionMaterial = material.get('originalVersionMaterial');
-		const subsequentVersionMaterials = material.get('subsequentVersionMaterials');
-		const productions = material.get('productions');
-		const sourcingMaterials = material.get('sourcingMaterials');
-		const sourcingMaterialProductions = material.get('sourcingMaterialProductions');
-		const awards = material.get('awards');
-		const subsequentVersionMaterialAwards = material.get('subsequentVersionMaterialAwards');
-		const sourcingMaterialAwards = material.get('sourcingMaterialAwards');
+	const instanceFacetSubheader = subheaderText =>
+		<div className="instance-facet-subheader">{ subheaderText }</div>;
 
-		const instanceFacetSubheader = subheaderText =>
-			<div className="instance-facet-subheader">{ subheaderText }</div>;
+	return (
+		<InstanceWrapper instance={material}>
 
-		return (
-			<InstanceWrapper instance={material}>
+			{
+				format && (
+					<InstanceFacet labelText='Format'>
 
-				{
-					format && (
-						<InstanceFacet labelText='Format'>
+						<React.Fragment>{ capitalise(format) }</React.Fragment>
 
-							<React.Fragment>{ capitalise(format) }</React.Fragment>
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				year && (
+					<InstanceFacet labelText='Year'>
 
-				{
-					year && (
-						<InstanceFacet labelText='Year'>
+						<React.Fragment>{ year }</React.Fragment>
 
-							<React.Fragment>{ year }</React.Fragment>
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				writingCredits?.size > 0 && (
+					<InstanceFacet labelText='Writers'>
 
-				{
-					writingCredits?.size > 0 && (
-						<InstanceFacet labelText='Writers'>
+						<WritingCredits credits={writingCredits} isAppendage={false} />
 
-							<WritingCredits credits={writingCredits} isAppendage={false} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				surMaterial && (
+					<InstanceFacet labelText='Part of'>
 
-				{
-					surMaterial && (
-						<InstanceFacet labelText='Part of'>
+						<InstanceLink instance={surMaterial} />
 
-							<InstanceLink instance={surMaterial} />
+						{
+							(surMaterial.get('format') || surMaterial.get('year')) && (
+								<AppendedFormatAndYear
+									format={surMaterial.get('format')}
+									year={surMaterial.get('year')}
+								/>
+							)
+						}
 
-							{
-								(surMaterial.get('format') || surMaterial.get('year')) && (
-									<AppendedFormatAndYear
-										format={surMaterial.get('format')}
-										year={surMaterial.get('year')}
-									/>
+						{
+							surMaterial.get('writingCredits')?.size > 0 && (
+								<AppendedWritingCredits credits={surMaterial.get('writingCredits')} />
+							)
+						}
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				subMaterials?.size > 0 && (
+					<InstanceFacet labelText='Comprises'>
+
+						<List instances={subMaterials} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				characterGroups?.size > 0 && (
+					<InstanceFacet labelText='Characters'>
+
+						{
+							characterGroups.size === 1
+								? (
+									<React.Fragment>
+
+										{
+											Boolean(characterGroups.first().get('name')) && (
+												instanceFacetSubheader(characterGroups.first().get('name'))
+											)
+										}
+
+										<List instances={characterGroups.first().get('characters')} />
+
+									</React.Fragment>
 								)
-							}
+								: (
+									<ul className="list list--no-bullets">
 
-							{
-								surMaterial.get('writingCredits')?.size > 0 && (
-									<AppendedWritingCredits credits={surMaterial.get('writingCredits')} />
+										{
+											characterGroups.map((characterGroup, index) =>
+												<li key={index} className="instance-facet-group">
+
+													{
+														Boolean(characterGroup.get('name')) && (
+															instanceFacetSubheader(characterGroup.get('name'))
+														)
+													}
+
+													<List instances={characterGroup.get('characters')} />
+
+												</li>
+											)
+										}
+
+									</ul>
 								)
-							}
+						}
 
-						</InstanceFacet>
-					)
-				}
+					</InstanceFacet>
+				)
+			}
 
-				{
-					subMaterials?.size > 0 && (
-						<InstanceFacet labelText='Comprises'>
+			{
+				originalVersionMaterial && (
+					<InstanceFacet labelText='Original version'>
 
-							<List instances={subMaterials} />
+						<InstanceLink instance={originalVersionMaterial} />
 
-						</InstanceFacet>
-					)
-				}
+						{
+							(originalVersionMaterial.get('format') || originalVersionMaterial.get('year')) && (
+								<AppendedFormatAndYear
+									format={originalVersionMaterial.get('format')}
+									year={originalVersionMaterial.get('year')}
+								/>
+							)
+						}
 
-				{
-					characterGroups?.size > 0 && (
-						<InstanceFacet labelText='Characters'>
+						{
+							originalVersionMaterial.get('writingCredits')?.size > 0 && (
+								<AppendedWritingCredits credits={originalVersionMaterial.get('writingCredits')} />
+							)
+						}
 
-							{
-								characterGroups.size === 1
-									? (
-										<React.Fragment>
+					</InstanceFacet>
+				)
+			}
 
-											{
-												Boolean(characterGroups.first().get('name')) && (
-													instanceFacetSubheader(characterGroups.first().get('name'))
-												)
-											}
+			{
+				subsequentVersionMaterials?.size > 0 && (
+					<InstanceFacet labelText='Subsequent versions'>
 
-											<List instances={characterGroups.first().get('characters')} />
+						<List instances={subsequentVersionMaterials} />
 
-										</React.Fragment>
-									)
-									: (
-										<ul className="list list--no-bullets">
+					</InstanceFacet>
+				)
+			}
 
-											{
-												characterGroups.map((characterGroup, index) =>
-													<li key={index} className="instance-facet-group">
+			{
+				productions?.size > 0 && (
+					<InstanceFacet labelText='Productions'>
 
-														{
-															Boolean(characterGroup.get('name')) && (
-																instanceFacetSubheader(characterGroup.get('name'))
+						<List instances={productions} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				sourcingMaterials?.size > 0 && (
+					<InstanceFacet labelText='Materials as source material'>
+
+						<List instances={sourcingMaterials} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				sourcingMaterialProductions?.size > 0 && (
+					<InstanceFacet labelText='Productions of materials as source material'>
+
+						<List instances={sourcingMaterialProductions} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				awards?.size > 0 && (
+					<InstanceFacet labelText='Awards'>
+
+						{
+							awards.map((award, index) =>
+								<React.Fragment key={index}>
+									<InstanceLink instance={award} />
+
+									<ul className="list">
+
+										{
+											award.get('ceremonies').map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
+
+													{
+														ceremony.get('categories')
+															.map((category, index) =>
+																<React.Fragment key={index}>
+																	{ category.get('name') }{': '}
+
+																	{
+																		category.get('nominations')
+																			.map((nomination, index) =>
+																				<React.Fragment key={index}>
+																					<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																						{nomination.get('type')}
+																					</span>
+
+																					{
+																						nomination.get('entities').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{': '}</React.Fragment>
+																								<Entities
+																									entities={nomination.get('entities')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('productions').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Productions
+																									productions={nomination.get('productions')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('productions').size > 0 &&
+																						(nomination.get('recipientMaterial') || nomination.get('coMaterials').size > 0) && (
+																							<React.Fragment>{';'}</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('recipientMaterial') && (
+																							<React.Fragment>
+																								<React.Fragment>{' (for '}</React.Fragment>
+																								<InstanceLink instance={nomination.get('recipientMaterial')} />
+																								{
+																									(nomination.getIn(['recipientMaterial', 'format']) || nomination.getIn(['recipientMaterial', 'year'])) && (
+																										<AppendedFormatAndYear
+																											format={nomination.getIn(['recipientMaterial', 'format'])}
+																											year={nomination.getIn(['recipientMaterial', 'year'])}
+																										/>
+																									)
+																								}
+																								<React.Fragment>{')'}</React.Fragment>
+																							</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('recipientMaterial') &&
+																						nomination.get('coMaterials').size > 0 && (
+																							<React.Fragment>{';'}</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('coMaterials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' (with '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('coMaterials')}
+																								/>
+																								<React.Fragment>{')'}</React.Fragment>
+																							</React.Fragment>
+																						)
+																					}
+																				</React.Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</React.Fragment>
 															)
-														}
-
-														<List instances={characterGroup.get('characters')} />
-
-													</li>
-												)
-											}
-
-										</ul>
-									)
-							}
-
-						</InstanceFacet>
-					)
-				}
-
-				{
-					originalVersionMaterial && (
-						<InstanceFacet labelText='Original version'>
-
-							<InstanceLink instance={originalVersionMaterial} />
-
-							{
-								(originalVersionMaterial.get('format') || originalVersionMaterial.get('year')) && (
-									<AppendedFormatAndYear
-										format={originalVersionMaterial.get('format')}
-										year={originalVersionMaterial.get('year')}
-									/>
-								)
-							}
-
-							{
-								originalVersionMaterial.get('writingCredits')?.size > 0 && (
-									<AppendedWritingCredits credits={originalVersionMaterial.get('writingCredits')} />
-								)
-							}
-
-						</InstanceFacet>
-					)
-				}
-
-				{
-					subsequentVersionMaterials?.size > 0 && (
-						<InstanceFacet labelText='Subsequent versions'>
-
-							<List instances={subsequentVersionMaterials} />
-
-						</InstanceFacet>
-					)
-				}
-
-				{
-					productions?.size > 0 && (
-						<InstanceFacet labelText='Productions'>
-
-							<List instances={productions} />
-
-						</InstanceFacet>
-					)
-				}
-
-				{
-					sourcingMaterials?.size > 0 && (
-						<InstanceFacet labelText='Materials as source material'>
-
-							<List instances={sourcingMaterials} />
-
-						</InstanceFacet>
-					)
-				}
-
-				{
-					sourcingMaterialProductions?.size > 0 && (
-						<InstanceFacet labelText='Productions of materials as source material'>
-
-							<List instances={sourcingMaterialProductions} />
-
-						</InstanceFacet>
-					)
-				}
-
-				{
-					awards?.size > 0 && (
-						<InstanceFacet labelText='Awards'>
-
-							{
-								awards.map((award, index) =>
-									<React.Fragment key={index}>
-										<InstanceLink instance={award} />
-
-										<ul className="list">
-
-											{
-												award.get('ceremonies').map((ceremony, index) =>
-													<li key={index}>
-														<InstanceLink instance={ceremony} />{': '}
-
-														{
-															ceremony.get('categories')
-																.map((category, index) =>
-																	<React.Fragment key={index}>
-																		{ category.get('name') }{': '}
-
-																		{
-																			category.get('nominations')
-																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
-																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
-																							{nomination.get('type')}
-																						</span>
-
-																						{
-																							nomination.get('entities').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{': '}</React.Fragment>
-																									<Entities
-																										entities={nomination.get('entities')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('productions').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Productions
-																										productions={nomination.get('productions')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('productions').size > 0 &&
-																							(nomination.get('recipientMaterial') || nomination.get('coMaterials').size > 0) && (
-																								<React.Fragment>{';'}</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('recipientMaterial') && (
-																								<React.Fragment>
-																									<React.Fragment>{' (for '}</React.Fragment>
-																									<InstanceLink instance={nomination.get('recipientMaterial')} />
-																									{
-																										(nomination.getIn(['recipientMaterial', 'format']) || nomination.getIn(['recipientMaterial', 'year'])) && (
-																											<AppendedFormatAndYear
-																												format={nomination.getIn(['recipientMaterial', 'format'])}
-																												year={nomination.getIn(['recipientMaterial', 'year'])}
-																											/>
-																										)
-																									}
-																									<React.Fragment>{')'}</React.Fragment>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('recipientMaterial') &&
-																							nomination.get('coMaterials').size > 0 && (
-																								<React.Fragment>{';'}</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('coMaterials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' (with '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('coMaterials')}
-																									/>
-																									<React.Fragment>{')'}</React.Fragment>
-																								</React.Fragment>
-																							)
-																						}
-																					</React.Fragment>
-																				)
-																				.reduce((prev, curr) => [prev, ', ', curr])
-																		}
-																	</React.Fragment>
-																)
-																.reduce((prev, curr) => [prev, '; ', curr])
-														}
-													</li>
-												)
-											}
-
-										</ul>
-									</React.Fragment>
-								)
-							}
-
-						</InstanceFacet>
-					)
-				}
-
-				{
-					subsequentVersionMaterialAwards?.size > 0 && (
-						<InstanceFacet labelText='Awards for subsequent versions'>
-
-							{
-								subsequentVersionMaterialAwards.map((subsequentVersionMaterialAward, index) =>
-									<React.Fragment key={index}>
-										<InstanceLink instance={subsequentVersionMaterialAward} />
-
-										<ul className="list">
-
-											{
-												subsequentVersionMaterialAward.get('ceremonies').map((ceremony, index) =>
-													<li key={index}>
-														<InstanceLink instance={ceremony} />{': '}
-
-														{
-															ceremony.get('categories')
-																.map((category, index) =>
-																	<React.Fragment key={index}>
-																		{ category.get('name') }{': '}
-
-																		{
-																			category.get('nominations')
-																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
-																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
-																							{nomination.get('type')}
-																						</span>
-
-																						{
-																							nomination.get('subsequentVersionMaterials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{': '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('subsequentVersionMaterials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('entities').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{': '}</React.Fragment>
-																									<Entities
-																										entities={nomination.get('entities')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('productions').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Productions
-																										productions={nomination.get('productions')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('productions').size > 0 &&
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>{';'}</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' (with '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('materials')}
-																									/>
-																									<React.Fragment>{')'}</React.Fragment>
-																								</React.Fragment>
-																							)
-																						}
-																					</React.Fragment>
-																				)
-																				.reduce((prev, curr) => [prev, ', ', curr])
-																		}
-																	</React.Fragment>
-																)
-																.reduce((prev, curr) => [prev, '; ', curr])
-														}
-													</li>
-												)
-											}
-
-										</ul>
-									</React.Fragment>
-								)
-							}
-
-						</InstanceFacet>
-					)
-				}
-
-				{
-					sourcingMaterialAwards?.size > 0 && (
-						<InstanceFacet labelText='Awards for materials as source material'>
-
-							{
-								sourcingMaterialAwards.map((sourcingMaterialAward, index) =>
-									<React.Fragment key={index}>
-										<InstanceLink instance={sourcingMaterialAward} />
-
-										<ul className="list">
-
-											{
-												sourcingMaterialAward.get('ceremonies').map((ceremony, index) =>
-													<li key={index}>
-														<InstanceLink instance={ceremony} />{': '}
-
-														{
-															ceremony.get('categories')
-																.map((category, index) =>
-																	<React.Fragment key={index}>
-																		{ category.get('name') }{': '}
-
-																		{
-																			category.get('nominations')
-																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
-																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
-																							{nomination.get('type')}
-																						</span>
-
-																						{
-																							nomination.get('sourcingMaterials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{': '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('sourcingMaterials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('entities').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{': '}</React.Fragment>
-																									<Entities
-																										entities={nomination.get('entities')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('productions').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Productions
-																										productions={nomination.get('productions')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('productions').size > 0 &&
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>{';'}</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' (with '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('materials')}
-																									/>
-																									<React.Fragment>{')'}</React.Fragment>
-																								</React.Fragment>
-																							)
-																						}
-																					</React.Fragment>
-																				)
-																				.reduce((prev, curr) => [prev, ', ', curr])
-																		}
-																	</React.Fragment>
-																)
-																.reduce((prev, curr) => [prev, '; ', curr])
-														}
-													</li>
-												)
-											}
-
-										</ul>
-									</React.Fragment>
-								)
-							}
-
-						</InstanceFacet>
-					)
-				}
-
-			</InstanceWrapper>
-		);
-
-	}
-
-}
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
+
+									</ul>
+								</React.Fragment>
+							)
+						}
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				subsequentVersionMaterialAwards?.size > 0 && (
+					<InstanceFacet labelText='Awards for subsequent versions'>
+
+						{
+							subsequentVersionMaterialAwards.map((subsequentVersionMaterialAward, index) =>
+								<React.Fragment key={index}>
+									<InstanceLink instance={subsequentVersionMaterialAward} />
+
+									<ul className="list">
+
+										{
+											subsequentVersionMaterialAward.get('ceremonies').map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
+
+													{
+														ceremony.get('categories')
+															.map((category, index) =>
+																<React.Fragment key={index}>
+																	{ category.get('name') }{': '}
+
+																	{
+																		category.get('nominations')
+																			.map((nomination, index) =>
+																				<React.Fragment key={index}>
+																					<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																						{nomination.get('type')}
+																					</span>
+
+																					{
+																						nomination.get('subsequentVersionMaterials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{': '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('subsequentVersionMaterials')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('entities').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{': '}</React.Fragment>
+																								<Entities
+																									entities={nomination.get('entities')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('productions').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Productions
+																									productions={nomination.get('productions')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('productions').size > 0 &&
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>{';'}</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' (with '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('materials')}
+																								/>
+																								<React.Fragment>{')'}</React.Fragment>
+																							</React.Fragment>
+																						)
+																					}
+																				</React.Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</React.Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
+
+									</ul>
+								</React.Fragment>
+							)
+						}
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				sourcingMaterialAwards?.size > 0 && (
+					<InstanceFacet labelText='Awards for materials as source material'>
+
+						{
+							sourcingMaterialAwards.map((sourcingMaterialAward, index) =>
+								<React.Fragment key={index}>
+									<InstanceLink instance={sourcingMaterialAward} />
+
+									<ul className="list">
+
+										{
+											sourcingMaterialAward.get('ceremonies').map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
+
+													{
+														ceremony.get('categories')
+															.map((category, index) =>
+																<React.Fragment key={index}>
+																	{ category.get('name') }{': '}
+
+																	{
+																		category.get('nominations')
+																			.map((nomination, index) =>
+																				<React.Fragment key={index}>
+																					<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																						{nomination.get('type')}
+																					</span>
+
+																					{
+																						nomination.get('sourcingMaterials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{': '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('sourcingMaterials')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('entities').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{': '}</React.Fragment>
+																								<Entities
+																									entities={nomination.get('entities')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('productions').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Productions
+																									productions={nomination.get('productions')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('productions').size > 0 &&
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>{';'}</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' (with '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('materials')}
+																								/>
+																								<React.Fragment>{')'}</React.Fragment>
+																							</React.Fragment>
+																						)
+																					}
+																				</React.Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</React.Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
+
+									</ul>
+								</React.Fragment>
+							)
+						}
+
+					</InstanceFacet>
+				)
+			}
+
+		</InstanceWrapper>
+	);
+
+};
 
 Material.propTypes = {
 	material: ImmutablePropTypes.map.isRequired

--- a/src/react/pages/instances/Person.jsx
+++ b/src/react/pages/instances/Person.jsx
@@ -14,527 +14,523 @@ import {
 } from '../../components';
 import { InstanceWrapper } from '../../utils';
 
-class Person extends React.Component {
+const Person = props => {
 
-	render () {
+	const { person } = props;
 
-		const { person } = this.props;
+	const materials = person.get('materials');
+	const subsequentVersionMaterials = person.get('subsequentVersionMaterials');
+	const sourcingMaterials = person.get('sourcingMaterials');
+	const rightsGrantorMaterials = person.get('rightsGrantorMaterials');
+	const producerProductions = person.get('producerProductions');
+	const castMemberProductions = person.get('castMemberProductions');
+	const creativeProductions = person.get('creativeProductions');
+	const crewProductions = person.get('crewProductions');
+	const awards = person.get('awards');
+	const subsequentVersionMaterialAwards = person.get('subsequentVersionMaterialAwards');
+	const sourcingMaterialAwards = person.get('sourcingMaterialAwards');
+	const rightsGrantorMaterialAwards = person.get('rightsGrantorMaterialAwards');
 
-		const materials = person.get('materials');
-		const subsequentVersionMaterials = person.get('subsequentVersionMaterials');
-		const sourcingMaterials = person.get('sourcingMaterials');
-		const rightsGrantorMaterials = person.get('rightsGrantorMaterials');
-		const producerProductions = person.get('producerProductions');
-		const castMemberProductions = person.get('castMemberProductions');
-		const creativeProductions = person.get('creativeProductions');
-		const crewProductions = person.get('crewProductions');
-		const awards = person.get('awards');
-		const subsequentVersionMaterialAwards = person.get('subsequentVersionMaterialAwards');
-		const sourcingMaterialAwards = person.get('sourcingMaterialAwards');
-		const rightsGrantorMaterialAwards = person.get('rightsGrantorMaterialAwards');
+	return (
+		<InstanceWrapper instance={person}>
 
-		return (
-			<InstanceWrapper instance={person}>
+			{
+				materials?.size > 0 && (
+					<InstanceFacet labelText='Materials'>
 
-				{
-					materials?.size > 0 && (
-						<InstanceFacet labelText='Materials'>
+						<List instances={materials} />
 
-							<List instances={materials} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				subsequentVersionMaterials?.size > 0 && (
+					<InstanceFacet labelText='Subsequent versions of their materials'>
 
-				{
-					subsequentVersionMaterials?.size > 0 && (
-						<InstanceFacet labelText='Subsequent versions of their materials'>
+						<List instances={subsequentVersionMaterials} />
 
-							<List instances={subsequentVersionMaterials} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				sourcingMaterials?.size > 0 && (
+					<InstanceFacet labelText='Materials as source material writer'>
 
-				{
-					sourcingMaterials?.size > 0 && (
-						<InstanceFacet labelText='Materials as source material writer'>
+						<List instances={sourcingMaterials} />
 
-							<List instances={sourcingMaterials} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				rightsGrantorMaterials?.size > 0 && (
+					<InstanceFacet labelText='Materials as rights grantor'>
 
-				{
-					rightsGrantorMaterials?.size > 0 && (
-						<InstanceFacet labelText='Materials as rights grantor'>
+						<List instances={rightsGrantorMaterials} />
 
-							<List instances={rightsGrantorMaterials} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				producerProductions?.size > 0 && (
+					<InstanceFacet labelText='Productions as producer'>
 
-				{
-					producerProductions?.size > 0 && (
-						<InstanceFacet labelText='Productions as producer'>
+						<List instances={producerProductions} />
 
-							<List instances={producerProductions} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				castMemberProductions?.size > 0 && (
+					<InstanceFacet labelText='Productions as cast member'>
 
-				{
-					castMemberProductions?.size > 0 && (
-						<InstanceFacet labelText='Productions as cast member'>
+						<List instances={castMemberProductions} />
 
-							<List instances={castMemberProductions} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				creativeProductions?.size > 0 && (
+					<InstanceFacet labelText='Productions as creative team member'>
 
-				{
-					creativeProductions?.size > 0 && (
-						<InstanceFacet labelText='Productions as creative team member'>
+						<List instances={creativeProductions} />
 
-							<List instances={creativeProductions} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				crewProductions?.size > 0 && (
+					<InstanceFacet labelText='Productions as crew member'>
 
-				{
-					crewProductions?.size > 0 && (
-						<InstanceFacet labelText='Productions as crew member'>
+						<List instances={crewProductions} />
 
-							<List instances={crewProductions} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				awards?.size > 0 && (
+					<InstanceFacet labelText='Awards'>
 
-				{
-					awards?.size > 0 && (
-						<InstanceFacet labelText='Awards'>
+						{
+							awards.map((award, index) =>
+								<React.Fragment key={index}>
+									<InstanceLink instance={award} />
 
-							{
-								awards.map((award, index) =>
-									<React.Fragment key={index}>
-										<InstanceLink instance={award} />
+									<ul className="list">
 
-										<ul className="list">
+										{
+											award.get('ceremonies').map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
 
-											{
-												award.get('ceremonies').map((ceremony, index) =>
-													<li key={index}>
-														<InstanceLink instance={ceremony} />{': '}
+													{
+														ceremony.get('categories')
+															.map((category, index) =>
+																<React.Fragment key={index}>
+																	{ category.get('name') }{': '}
 
-														{
-															ceremony.get('categories')
-																.map((category, index) =>
-																	<React.Fragment key={index}>
-																		{ category.get('name') }{': '}
+																	{
+																		category.get('nominations')
+																			.map((nomination, index) =>
+																				<React.Fragment key={index}>
+																					<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																						{nomination.get('type')}
+																					</span>
 
-																		{
-																			category.get('nominations')
-																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
-																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
-																							{nomination.get('type')}
-																						</span>
+																					{
+																						nomination.get('employerCompany') && (
+																							<AppendedEmployerCompany
+																								employerCompany={nomination.get('employerCompany')}
+																							/>
+																						)
+																					}
 
-																						{
-																							nomination.get('employerCompany') && (
-																								<AppendedEmployerCompany
-																									employerCompany={nomination.get('employerCompany')}
+																					{
+																						nomination.get('coEntities').size > 0 && (
+																							<AppendedCoEntities
+																								coEntities={nomination.get('coEntities')}
+																							/>
+																						)
+																					}
+
+																					{
+																						nomination.get('productions').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Productions
+																									productions={nomination.get('productions')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('coEntities').size > 0 && (
-																								<AppendedCoEntities
-																									coEntities={nomination.get('coEntities')}
+																					{
+																						nomination.get('productions').size > 0 &&
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>{';'}</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('materials')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
+																				</React.Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</React.Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
 
-																						{
-																							nomination.get('productions').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Productions
-																										productions={nomination.get('productions')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
+									</ul>
+								</React.Fragment>
+							)
+						}
 
-																						{
-																							nomination.get('productions').size > 0 &&
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>{';'}</React.Fragment>
-																							)
-																						}
+					</InstanceFacet>
+				)
+			}
 
-																						{
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('materials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-																					</React.Fragment>
-																				)
-																				.reduce((prev, curr) => [prev, ', ', curr])
-																		}
-																	</React.Fragment>
-																)
-																.reduce((prev, curr) => [prev, '; ', curr])
-														}
-													</li>
-												)
-											}
+			{
+				subsequentVersionMaterialAwards?.size > 0 && (
+					<InstanceFacet labelText='Awards for subsequent versions of their material'>
 
-										</ul>
-									</React.Fragment>
-								)
-							}
+						{
+							subsequentVersionMaterialAwards.map((subsequentVersionMaterialAward, index) =>
+								<React.Fragment key={index}>
+									<InstanceLink instance={subsequentVersionMaterialAward} />
 
-						</InstanceFacet>
-					)
-				}
+									<ul className="list">
 
-				{
-					subsequentVersionMaterialAwards?.size > 0 && (
-						<InstanceFacet labelText='Awards for subsequent versions of their material'>
+										{
+											subsequentVersionMaterialAward.get('ceremonies').map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
 
-							{
-								subsequentVersionMaterialAwards.map((subsequentVersionMaterialAward, index) =>
-									<React.Fragment key={index}>
-										<InstanceLink instance={subsequentVersionMaterialAward} />
+													{
+														ceremony.get('categories')
+															.map((category, index) =>
+																<React.Fragment key={index}>
+																	{ category.get('name') }{': '}
 
-										<ul className="list">
+																	{
+																		category.get('nominations')
+																			.map((nomination, index) =>
+																				<React.Fragment key={index}>
+																					<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																						{nomination.get('type')}
+																					</span>
 
-											{
-												subsequentVersionMaterialAward.get('ceremonies').map((ceremony, index) =>
-													<li key={index}>
-														<InstanceLink instance={ceremony} />{': '}
-
-														{
-															ceremony.get('categories')
-																.map((category, index) =>
-																	<React.Fragment key={index}>
-																		{ category.get('name') }{': '}
-
-																		{
-																			category.get('nominations')
-																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
-																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
-																							{nomination.get('type')}
-																						</span>
-
-																						{
-																							nomination.get('subsequentVersionMaterials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{': '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('subsequentVersionMaterials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('employerCompany') && (
-																								<AppendedEmployerCompany
-																									employerCompany={nomination.get('employerCompany')}
+																					{
+																						nomination.get('subsequentVersionMaterials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{': '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('subsequentVersionMaterials')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('entities').size > 0 && (
-																								<AppendedEntities
-																									entities={nomination.get('entities')}
+																					{
+																						nomination.get('employerCompany') && (
+																							<AppendedEmployerCompany
+																								employerCompany={nomination.get('employerCompany')}
+																							/>
+																						)
+																					}
+
+																					{
+																						nomination.get('entities').size > 0 && (
+																							<AppendedEntities
+																								entities={nomination.get('entities')}
+																							/>
+																						)
+																					}
+
+																					{
+																						nomination.get('productions').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Productions
+																									productions={nomination.get('productions')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('productions').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Productions
-																										productions={nomination.get('productions')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
+																					{
+																						nomination.get('productions').size > 0 &&
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>{';'}</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('productions').size > 0 &&
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>{';'}</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('materials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-																					</React.Fragment>
-																				)
-																				.reduce((prev, curr) => [prev, ', ', curr])
-																		}
-																	</React.Fragment>
-																)
-																.reduce((prev, curr) => [prev, '; ', curr])
-														}
-													</li>
-												)
-											}
-
-										</ul>
-									</React.Fragment>
-								)
-							}
-
-						</InstanceFacet>
-					)
-				}
-
-				{
-					sourcingMaterialAwards?.size > 0 && (
-						<InstanceFacet labelText='Awards for materials as source material writer'>
-
-							{
-								sourcingMaterialAwards.map((sourcingMaterialAward, index) =>
-									<React.Fragment key={index}>
-										<InstanceLink instance={sourcingMaterialAward} />
-
-										<ul className="list">
-
-											{
-												sourcingMaterialAward.get('ceremonies').map((ceremony, index) =>
-													<li key={index}>
-														<InstanceLink instance={ceremony} />{': '}
-
-														{
-															ceremony.get('categories')
-																.map((category, index) =>
-																	<React.Fragment key={index}>
-																		{ category.get('name') }{': '}
-
-																		{
-																			category.get('nominations')
-																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
-																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
-																							{nomination.get('type')}
-																						</span>
-
-																						{
-																							nomination.get('sourcingMaterials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{': '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('sourcingMaterials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('employerCompany') && (
-																								<AppendedEmployerCompany
-																									employerCompany={nomination.get('employerCompany')}
+																					{
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('materials')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
+																				</React.Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</React.Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
 
-																						{
-																							nomination.get('entities').size > 0 && (
-																								<AppendedEntities
-																									entities={nomination.get('entities')}
+									</ul>
+								</React.Fragment>
+							)
+						}
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				sourcingMaterialAwards?.size > 0 && (
+					<InstanceFacet labelText='Awards for materials as source material writer'>
+
+						{
+							sourcingMaterialAwards.map((sourcingMaterialAward, index) =>
+								<React.Fragment key={index}>
+									<InstanceLink instance={sourcingMaterialAward} />
+
+									<ul className="list">
+
+										{
+											sourcingMaterialAward.get('ceremonies').map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
+
+													{
+														ceremony.get('categories')
+															.map((category, index) =>
+																<React.Fragment key={index}>
+																	{ category.get('name') }{': '}
+
+																	{
+																		category.get('nominations')
+																			.map((nomination, index) =>
+																				<React.Fragment key={index}>
+																					<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																						{nomination.get('type')}
+																					</span>
+
+																					{
+																						nomination.get('sourcingMaterials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{': '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('sourcingMaterials')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('productions').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Productions
-																										productions={nomination.get('productions')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
+																					{
+																						nomination.get('employerCompany') && (
+																							<AppendedEmployerCompany
+																								employerCompany={nomination.get('employerCompany')}
+																							/>
+																						)
+																					}
 
-																						{
-																							nomination.get('productions').size > 0 &&
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>{';'}</React.Fragment>
-																							)
-																						}
+																					{
+																						nomination.get('entities').size > 0 && (
+																							<AppendedEntities
+																								entities={nomination.get('entities')}
+																							/>
+																						)
+																					}
 
-																						{
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('materials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-																					</React.Fragment>
-																				)
-																				.reduce((prev, curr) => [prev, ', ', curr])
-																		}
-																	</React.Fragment>
-																)
-																.reduce((prev, curr) => [prev, '; ', curr])
-														}
-													</li>
-												)
-											}
-
-										</ul>
-									</React.Fragment>
-								)
-							}
-
-						</InstanceFacet>
-					)
-				}
-
-				{
-					rightsGrantorMaterialAwards?.size > 0 && (
-						<InstanceFacet labelText='Awards for materials as rights grantor'>
-
-							{
-								rightsGrantorMaterialAwards.map((rightsGrantorMaterialAward, index) =>
-									<React.Fragment key={index}>
-										<InstanceLink instance={rightsGrantorMaterialAward} />
-
-										<ul className="list">
-
-											{
-												rightsGrantorMaterialAward.get('ceremonies').map((ceremony, index) =>
-													<li key={index}>
-														<InstanceLink instance={ceremony} />{': '}
-
-														{
-															ceremony.get('categories')
-																.map((category, index) =>
-																	<React.Fragment key={index}>
-																		{ category.get('name') }{': '}
-
-																		{
-																			category.get('nominations')
-																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
-																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
-																							{nomination.get('type')}
-																						</span>
-
-																						{
-																							nomination.get('rightsGrantorMaterials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{': '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('rightsGrantorMaterials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-
-																						{
-																							nomination.get('employerCompany') && (
-																								<AppendedEmployerCompany
-																									employerCompany={nomination.get('employerCompany')}
+																					{
+																						nomination.get('productions').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Productions
+																									productions={nomination.get('productions')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('entities').size > 0 && (
-																								<AppendedEntities
-																									entities={nomination.get('entities')}
+																					{
+																						nomination.get('productions').size > 0 &&
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>{';'}</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('materials')}
 																								/>
-																							)
-																						}
+																							</React.Fragment>
+																						)
+																					}
+																				</React.Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</React.Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
 
-																						{
-																							nomination.get('productions').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Productions
-																										productions={nomination.get('productions')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
+									</ul>
+								</React.Fragment>
+							)
+						}
 
-																						{
-																							nomination.get('productions').size > 0 &&
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>{';'}</React.Fragment>
-																							)
-																						}
+					</InstanceFacet>
+				)
+			}
 
-																						{
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('materials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-																					</React.Fragment>
-																				)
-																				.reduce((prev, curr) => [prev, ', ', curr])
-																		}
-																	</React.Fragment>
-																)
-																.reduce((prev, curr) => [prev, '; ', curr])
-														}
-													</li>
-												)
-											}
+			{
+				rightsGrantorMaterialAwards?.size > 0 && (
+					<InstanceFacet labelText='Awards for materials as rights grantor'>
 
-										</ul>
-									</React.Fragment>
-								)
-							}
+						{
+							rightsGrantorMaterialAwards.map((rightsGrantorMaterialAward, index) =>
+								<React.Fragment key={index}>
+									<InstanceLink instance={rightsGrantorMaterialAward} />
 
-						</InstanceFacet>
-					)
-				}
+									<ul className="list">
 
-			</InstanceWrapper>
-		);
+										{
+											rightsGrantorMaterialAward.get('ceremonies').map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
 
-	}
+													{
+														ceremony.get('categories')
+															.map((category, index) =>
+																<React.Fragment key={index}>
+																	{ category.get('name') }{': '}
 
-}
+																	{
+																		category.get('nominations')
+																			.map((nomination, index) =>
+																				<React.Fragment key={index}>
+																					<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																						{nomination.get('type')}
+																					</span>
+
+																					{
+																						nomination.get('rightsGrantorMaterials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{': '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('rightsGrantorMaterials')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('employerCompany') && (
+																							<AppendedEmployerCompany
+																								employerCompany={nomination.get('employerCompany')}
+																							/>
+																						)
+																					}
+
+																					{
+																						nomination.get('entities').size > 0 && (
+																							<AppendedEntities
+																								entities={nomination.get('entities')}
+																							/>
+																						)
+																					}
+
+																					{
+																						nomination.get('productions').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Productions
+																									productions={nomination.get('productions')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('productions').size > 0 &&
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>{';'}</React.Fragment>
+																						)
+																					}
+
+																					{
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('materials')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+																				</React.Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</React.Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
+
+									</ul>
+								</React.Fragment>
+							)
+						}
+
+					</InstanceFacet>
+				)
+			}
+
+		</InstanceWrapper>
+	);
+
+};
 
 Person.propTypes = {
 	person: ImmutablePropTypes.map.isRequired

--- a/src/react/pages/instances/Production.jsx
+++ b/src/react/pages/instances/Production.jsx
@@ -17,244 +17,240 @@ import {
 } from '../../components';
 import { InstanceWrapper } from '../../utils';
 
-class Production extends React.Component {
+const Production = props => {
 
-	render () {
+	const { production } = props;
 
-		const { production } = this.props;
+	const material = production.get('material');
+	const startDate = production.get('startDate');
+	const pressDate = production.get('pressDate');
+	const endDate = production.get('endDate');
+	const venue = production.get('venue');
+	const producerCredits = production.get('producerCredits');
+	const cast = production.get('cast');
+	const creativeCredits = production.get('creativeCredits');
+	const crewCredits = production.get('crewCredits');
+	const awards = production.get('awards');
 
-		const material = production.get('material');
-		const startDate = production.get('startDate');
-		const pressDate = production.get('pressDate');
-		const endDate = production.get('endDate');
-		const venue = production.get('venue');
-		const producerCredits = production.get('producerCredits');
-		const cast = production.get('cast');
-		const creativeCredits = production.get('creativeCredits');
-		const crewCredits = production.get('crewCredits');
-		const awards = production.get('awards');
+	const dateFormatOptions = { weekday: 'long', month: 'long' };
 
-		const dateFormatOptions = { weekday: 'long', month: 'long' };
+	return (
+		<InstanceWrapper instance={production}>
 
-		return (
-			<InstanceWrapper instance={production}>
+			{
+				material && (
+					<InstanceFacet labelText='Material'>
 
-				{
-					material && (
-						<InstanceFacet labelText='Material'>
+						{
+							material.get('surMaterial') && (
+								<PrependedSurMaterial surMaterial={material.get('surMaterial')} />
+							)
+						}
 
-							{
-								material.get('surMaterial') && (
-									<PrependedSurMaterial surMaterial={material.get('surMaterial')} />
-								)
-							}
+						<InstanceLink instance={material} />
 
-							<InstanceLink instance={material} />
+						{
+							(material.get('format') || material.get('year')) && (
+								<AppendedFormatAndYear
+									format={material.get('format')}
+									year={material.get('year')}
+								/>
+							)
+						}
 
-							{
-								(material.get('format') || material.get('year')) && (
-									<AppendedFormatAndYear
-										format={material.get('format')}
-										year={material.get('year')}
-									/>
-								)
-							}
+						{
+							material.get('writingCredits')?.size > 0 && (
+								<AppendedWritingCredits credits={material.get('writingCredits')} />
+							)
+						}
 
-							{
-								material.get('writingCredits')?.size > 0 && (
-									<AppendedWritingCredits credits={material.get('writingCredits')} />
-								)
-							}
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				(startDate || pressDate || endDate) && (
+					<InstanceFacet labelText='Dates'>
 
-				{
-					(startDate || pressDate || endDate) && (
-						<InstanceFacet labelText='Dates'>
+						{
+							startDate && (
+								<div>
+									<b>Starts:</b>{` ${formatDate(startDate, dateFormatOptions)}`}
+								</div>
+							)
+						}
 
-							{
-								startDate && (
-									<div>
-										<b>Starts:</b>{` ${formatDate(startDate, dateFormatOptions)}`}
-									</div>
-								)
-							}
+						{
+							pressDate && (
+								<div>
+									<b>Press:</b>{` ${formatDate(pressDate, dateFormatOptions)}`}
+								</div>
+							)
+						}
 
-							{
-								pressDate && (
-									<div>
-										<b>Press:</b>{` ${formatDate(pressDate, dateFormatOptions)}`}
-									</div>
-								)
-							}
+						{
+							endDate && (
+								<div>
+									<b>Ends:</b>{` ${formatDate(endDate, dateFormatOptions)}`}
+								</div>
+							)
+						}
 
-							{
-								endDate && (
-									<div>
-										<b>Ends:</b>{` ${formatDate(endDate, dateFormatOptions)}`}
-									</div>
-								)
-							}
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				venue && (
+					<InstanceFacet labelText='Venue'>
 
-				{
-					venue && (
-						<InstanceFacet labelText='Venue'>
+						{
+							venue.get('surVenue') && (
+								<span><InstanceLink instance={venue.get('surVenue')} />: </span>
+							)
+						}
 
-							{
-								venue.get('surVenue') && (
-									<span><InstanceLink instance={venue.get('surVenue')} />: </span>
-								)
-							}
+						<InstanceLink instance={venue} />
 
-							<InstanceLink instance={venue} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				producerCredits?.size > 0 && (
+					<InstanceFacet labelText='Producers'>
 
-				{
-					producerCredits?.size > 0 && (
-						<InstanceFacet labelText='Producers'>
+						<ProducerCredits credits={producerCredits} />
 
-							<ProducerCredits credits={producerCredits} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				cast?.size > 0 && (
+					<InstanceFacet labelText='Cast'>
 
-				{
-					cast?.size > 0 && (
-						<InstanceFacet labelText='Cast'>
+						<List instances={cast} />
 
-							<List instances={cast} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				creativeCredits?.size > 0 && (
+					<InstanceFacet labelText='Creative Team'>
 
-				{
-					creativeCredits?.size > 0 && (
-						<InstanceFacet labelText='Creative Team'>
+						<List instances={creativeCredits} />
 
-							<List instances={creativeCredits} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				crewCredits?.size > 0 && (
+					<InstanceFacet labelText='Crew'>
 
-				{
-					crewCredits?.size > 0 && (
-						<InstanceFacet labelText='Crew'>
+						<List instances={crewCredits} />
 
-							<List instances={crewCredits} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				awards?.size > 0 && (
+					<InstanceFacet labelText='Awards'>
 
-				{
-					awards?.size > 0 && (
-						<InstanceFacet labelText='Awards'>
+						{
+							awards.map((award, index) =>
+								<React.Fragment key={index}>
+									<InstanceLink instance={award} />
 
-							{
-								awards.map((award, index) =>
-									<React.Fragment key={index}>
-										<InstanceLink instance={award} />
+									<ul className="list">
 
-										<ul className="list">
+										{
+											award.get('ceremonies').map((ceremony, index) =>
+												<li key={index}>
+													<InstanceLink instance={ceremony} />{': '}
 
-											{
-												award.get('ceremonies').map((ceremony, index) =>
-													<li key={index}>
-														<InstanceLink instance={ceremony} />{': '}
+													{
+														ceremony.get('categories')
+															.map((category, index) =>
+																<React.Fragment key={index}>
+																	{ category.get('name') }{': '}
 
-														{
-															ceremony.get('categories')
-																.map((category, index) =>
-																	<React.Fragment key={index}>
-																		{ category.get('name') }{': '}
+																	{
+																		category.get('nominations')
+																			.map((nomination, index) =>
+																				<React.Fragment key={index}>
+																					<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
+																						{nomination.get('type')}
+																					</span>
 
-																		{
-																			category.get('nominations')
-																				.map((nomination, index) =>
-																					<React.Fragment key={index}>
-																						<span className={nomination.get('isWinner') ? 'nomination-winner-text' : ''}>
-																							{nomination.get('type')}
-																						</span>
+																					{
+																						nomination.get('entities').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{': '}</React.Fragment>
+																								<Entities
+																									entities={nomination.get('entities')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('entities').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{': '}</React.Fragment>
-																									<Entities
-																										entities={nomination.get('entities')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
+																					{
+																						nomination.get('coProductions').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' (with '}</React.Fragment>
+																								<Productions
+																									productions={nomination.get('coProductions')}
+																								/>
+																								<React.Fragment>{')'}</React.Fragment>
+																							</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('coProductions').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' (with '}</React.Fragment>
-																									<Productions
-																										productions={nomination.get('coProductions')}
-																									/>
-																									<React.Fragment>{')'}</React.Fragment>
-																								</React.Fragment>
-																							)
-																						}
+																					{
+																						nomination.get('coProductions').size > 0 &&
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>{';'}</React.Fragment>
+																						)
+																					}
 
-																						{
-																							nomination.get('coProductions').size > 0 &&
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>{';'}</React.Fragment>
-																							)
-																						}
+																					{
+																						nomination.get('materials').size > 0 && (
+																							<React.Fragment>
+																								<React.Fragment>{' for '}</React.Fragment>
+																								<Materials
+																									materials={nomination.get('materials')}
+																								/>
+																							</React.Fragment>
+																						)
+																					}
+																				</React.Fragment>
+																			)
+																			.reduce((prev, curr) => [prev, ', ', curr])
+																	}
+																</React.Fragment>
+															)
+															.reduce((prev, curr) => [prev, '; ', curr])
+													}
+												</li>
+											)
+										}
 
-																						{
-																							nomination.get('materials').size > 0 && (
-																								<React.Fragment>
-																									<React.Fragment>{' for '}</React.Fragment>
-																									<Materials
-																										materials={nomination.get('materials')}
-																									/>
-																								</React.Fragment>
-																							)
-																						}
-																					</React.Fragment>
-																				)
-																				.reduce((prev, curr) => [prev, ', ', curr])
-																		}
-																	</React.Fragment>
-																)
-																.reduce((prev, curr) => [prev, '; ', curr])
-														}
-													</li>
-												)
-											}
+									</ul>
+								</React.Fragment>
+							)
+						}
 
-										</ul>
-									</React.Fragment>
-								)
-							}
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+		</InstanceWrapper>
+	);
 
-			</InstanceWrapper>
-		);
-
-	}
-
-}
+};
 
 Production.propTypes = {
 	production: ImmutablePropTypes.map.isRequired

--- a/src/react/pages/instances/Venue.jsx
+++ b/src/react/pages/instances/Venue.jsx
@@ -5,55 +5,51 @@ import { connect } from 'react-redux';
 import { InstanceFacet, InstanceLink, List } from '../../components';
 import { InstanceWrapper } from '../../utils';
 
-class Venue extends React.Component {
+const Venue = props => {
 
-	render () {
+	const { venue } = props;
 
-		const { venue } = this.props;
+	const surVenue = venue.get('surVenue');
+	const subVenues = venue.get('subVenues');
+	const productions = venue.get('productions');
 
-		const surVenue = venue.get('surVenue');
-		const subVenues = venue.get('subVenues');
-		const productions = venue.get('productions');
+	return (
+		<InstanceWrapper instance={venue}>
 
-		return (
-			<InstanceWrapper instance={venue}>
+			{
+				surVenue && (
+					<InstanceFacet labelText='Part of'>
 
-				{
-					surVenue && (
-						<InstanceFacet labelText='Part of'>
+						<InstanceLink instance={surVenue} />
 
-							<InstanceLink instance={surVenue} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				subVenues?.size > 0 && (
+					<InstanceFacet labelText='Comprises'>
 
-				{
-					subVenues?.size > 0 && (
-						<InstanceFacet labelText='Comprises'>
+						<List instances={subVenues} />
 
-							<List instances={subVenues} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+			{
+				productions?.size > 0 && (
+					<InstanceFacet labelText='Productions'>
 
-				{
-					productions?.size > 0 && (
-						<InstanceFacet labelText='Productions'>
+						<List instances={productions} />
 
-							<List instances={productions} />
+					</InstanceFacet>
+				)
+			}
 
-						</InstanceFacet>
-					)
-				}
+		</InstanceWrapper>
+	);
 
-			</InstanceWrapper>
-		);
-
-	}
-
-}
+};
 
 Venue.propTypes = {
 	venue: ImmutablePropTypes.map.isRequired

--- a/src/react/pages/lists/AwardCeremonies.jsx
+++ b/src/react/pages/lists/AwardCeremonies.jsx
@@ -4,23 +4,19 @@ import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../utils';
 
-class AwardCeremonies extends React.Component {
+const AwardCeremonies = props => {
 
-	render () {
+	const { awardCeremonies } = props;
 
-		const { awardCeremonies } = this.props;
+	return (
+		<ListWrapper
+			instances={awardCeremonies}
+			pageTitleText='Award ceremonies'
+		>
+		</ListWrapper>
+	);
 
-		return (
-			<ListWrapper
-				instances={awardCeremonies}
-				pageTitleText='Award ceremonies'
-			>
-			</ListWrapper>
-		);
-
-	}
-
-}
+};
 
 AwardCeremonies.propTypes = {
 	awardCeremonies: ImmutablePropTypes.list.isRequired

--- a/src/react/pages/lists/Awards.jsx
+++ b/src/react/pages/lists/Awards.jsx
@@ -4,23 +4,19 @@ import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../utils';
 
-class Awards extends React.Component {
+const Awards = props => {
 
-	render () {
+	const { awards } = props;
 
-		const { awards } = this.props;
+	return (
+		<ListWrapper
+			instances={awards}
+			pageTitleText='Awards'
+		>
+		</ListWrapper>
+	);
 
-		return (
-			<ListWrapper
-				instances={awards}
-				pageTitleText='Awards'
-			>
-			</ListWrapper>
-		);
-
-	}
-
-}
+};
 
 Awards.propTypes = {
 	awards: ImmutablePropTypes.list.isRequired

--- a/src/react/pages/lists/Characters.jsx
+++ b/src/react/pages/lists/Characters.jsx
@@ -4,23 +4,19 @@ import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../utils';
 
-class Characters extends React.Component {
+const Characters = props => {
 
-	render () {
+	const { characters } = props;
 
-		const { characters } = this.props;
+	return (
+		<ListWrapper
+			instances={characters}
+			pageTitleText='Characters'
+		>
+		</ListWrapper>
+	);
 
-		return (
-			<ListWrapper
-				instances={characters}
-				pageTitleText='Characters'
-			>
-			</ListWrapper>
-		);
-
-	}
-
-}
+};
 
 Characters.propTypes = {
 	characters: ImmutablePropTypes.list.isRequired

--- a/src/react/pages/lists/Companies.jsx
+++ b/src/react/pages/lists/Companies.jsx
@@ -4,23 +4,19 @@ import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../utils';
 
-class Companies extends React.Component {
+const Companies = props => {
 
-	render () {
+	const { companies } = props;
 
-		const { companies } = this.props;
+	return (
+		<ListWrapper
+			instances={companies}
+			pageTitleText='Companies'
+		>
+		</ListWrapper>
+	);
 
-		return (
-			<ListWrapper
-				instances={companies}
-				pageTitleText='Companies'
-			>
-			</ListWrapper>
-		);
-
-	}
-
-}
+};
 
 Companies.propTypes = {
 	companies: ImmutablePropTypes.list.isRequired

--- a/src/react/pages/lists/Materials.jsx
+++ b/src/react/pages/lists/Materials.jsx
@@ -4,23 +4,19 @@ import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../utils';
 
-class Materials extends React.Component {
+const Materials = props => {
 
-	render () {
+	const { materials } = props;
 
-		const { materials } = this.props;
+	return (
+		<ListWrapper
+			instances={materials}
+			pageTitleText='Materials'
+		>
+		</ListWrapper>
+	);
 
-		return (
-			<ListWrapper
-				instances={materials}
-				pageTitleText='Materials'
-			>
-			</ListWrapper>
-		);
-
-	}
-
-}
+};
 
 Materials.propTypes = {
 	materials: ImmutablePropTypes.list.isRequired

--- a/src/react/pages/lists/People.jsx
+++ b/src/react/pages/lists/People.jsx
@@ -4,23 +4,19 @@ import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../utils';
 
-class People extends React.Component {
+const People = props => {
 
-	render () {
+	const { people } = props;
 
-		const { people } = this.props;
+	return (
+		<ListWrapper
+			instances={people}
+			pageTitleText='People'
+		>
+		</ListWrapper>
+	);
 
-		return (
-			<ListWrapper
-				instances={people}
-				pageTitleText='People'
-			>
-			</ListWrapper>
-		);
-
-	}
-
-}
+};
 
 People.propTypes = {
 	people: ImmutablePropTypes.list.isRequired

--- a/src/react/pages/lists/Productions.jsx
+++ b/src/react/pages/lists/Productions.jsx
@@ -4,23 +4,19 @@ import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../utils';
 
-class Productions extends React.Component {
+const Productions = props => {
 
-	render () {
+	const { productions } = props;
 
-		const { productions } = this.props;
+	return (
+		<ListWrapper
+			instances={productions}
+			pageTitleText='Productions'
+		>
+		</ListWrapper>
+	);
 
-		return (
-			<ListWrapper
-				instances={productions}
-				pageTitleText='Productions'
-			>
-			</ListWrapper>
-		);
-
-	}
-
-}
+};
 
 Productions.propTypes = {
 	productions: ImmutablePropTypes.list.isRequired

--- a/src/react/pages/lists/Venues.jsx
+++ b/src/react/pages/lists/Venues.jsx
@@ -4,23 +4,19 @@ import { connect } from 'react-redux';
 
 import { ListWrapper } from '../../utils';
 
-class Venues extends React.Component {
+const Venues = props => {
 
-	render () {
+	const { venues } = props;
 
-		const { venues } = this.props;
+	return (
+		<ListWrapper
+			instances={venues}
+			pageTitleText='Venues'
+		>
+		</ListWrapper>
+	);
 
-		return (
-			<ListWrapper
-				instances={venues}
-				pageTitleText='Venues'
-			>
-			</ListWrapper>
-		);
-
-	}
-
-}
+};
 
 Venues.propTypes = {
 	venues: ImmutablePropTypes.list.isRequired

--- a/src/react/utils/FetchDataOnMountWrapper.jsx
+++ b/src/react/utils/FetchDataOnMountWrapper.jsx
@@ -1,65 +1,62 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useEffect } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
+import { useRouteMatch } from 'react-router-dom';
 
 import { ErrorMessage, Footer, Header, Navigation } from '../components';
 
-class FetchDataOnMountWrapper extends React.Component {
+const FetchDataOnMountWrapper = props => {
 
-	componentDidMount () {
+	const { documentTitle, error, children } = props;
 
-		const { fetchData, dispatch, match } = this.props;
+	const match = useRouteMatch();
+
+	useEffect(() => {
+
+		const { fetchData, dispatch } = props;
 
 		if (fetchData) fetchData.map(fetchDataFunction => fetchDataFunction(dispatch, match));
 
-	}
+	}, []);
 
-	render () {
+	return (
+		<React.Fragment>
 
-		const { documentTitle, error, children } = this.props;
+			<Helmet
+				defaultTitle='TheatreBase'
+				titleTemplate='%s | TheatreBase'
+				title={documentTitle()}
+			/>
 
-		return (
-			<React.Fragment>
+			<Header />
 
-				<Helmet
-					defaultTitle='TheatreBase'
-					titleTemplate='%s | TheatreBase'
-					title={documentTitle()}
-				/>
+			<Navigation />
 
-				<Header />
+			<main className="main-content">
 
-				<Navigation />
+				{
+					error.get('isExistent')
+						? <ErrorMessage errorText={error.get('message')} />
+						: children
+				}
 
-				<main className="main-content">
+			</main>
 
-					{
-						error.get('isExistent')
-							? <ErrorMessage errorText={error.get('message')} />
-							: children
-					}
+			<Footer />
 
-				</main>
+		</React.Fragment>
+	);
 
-				<Footer />
-
-			</React.Fragment>
-		);
-
-	}
-
-}
+};
 
 FetchDataOnMountWrapper.propTypes = {
 	documentTitle: PropTypes.func.isRequired,
 	error: ImmutablePropTypes.map.isRequired,
 	children: PropTypes.node.isRequired,
 	fetchData: PropTypes.array.isRequired,
-	dispatch: PropTypes.func.isRequired,
-	match: PropTypes.object.isRequired,
-	location: PropTypes.object.isRequired
+	dispatch: PropTypes.func.isRequired
 };
 
 const mapStateToProps = state => ({

--- a/src/react/utils/InstanceWrapper.jsx
+++ b/src/react/utils/InstanceWrapper.jsx
@@ -6,48 +6,44 @@ import getDifferentiatorSuffix from '../../lib/get-differentiator-suffix';
 import getInstanceTitle from '../../lib/get-instance-title';
 import { InstanceDocumentTitle, InstanceLabel, PageTitle } from '../components';
 
-class InstanceWrapper extends React.Component {
+const InstanceWrapper = props => {
 
-	render () {
+	const { instance, children } = props;
 
-		const { instance, children } = this.props;
+	const title = getInstanceTitle(instance);
 
-		const title = getInstanceTitle(instance);
+	const differentiatorSuffix = getDifferentiatorSuffix(instance.get('differentiator'));
 
-		const differentiatorSuffix = getDifferentiatorSuffix(instance.get('differentiator'));
+	const pageTitleText = [
+		title,
+		differentiatorSuffix
+	]
+		.filter(Boolean)
+		.join(' ');
 
-		const pageTitleText = [
-			title,
-			differentiatorSuffix
-		]
-			.filter(Boolean)
-			.join(' ');
+	return (
+		<React.Fragment>
 
-		return (
-			<React.Fragment>
+			{
+				instance.get('name') && instance.get('model') && (
+					<InstanceDocumentTitle
+						title={title}
+						model={instance.get('model')}
+						differentiatorSuffix={differentiatorSuffix}
+					/>
+				)
+			}
 
-				{
-					instance.get('name') && instance.get('model') && (
-						<InstanceDocumentTitle
-							title={title}
-							model={instance.get('model')}
-							differentiatorSuffix={differentiatorSuffix}
-						/>
-					)
-				}
+			<InstanceLabel model={instance.get('model', '')} />
 
-				<InstanceLabel model={instance.get('model', '')} />
+			<PageTitle text={pageTitleText} />
 
-				<PageTitle text={pageTitleText} />
+			{ children }
 
-				{ children }
+		</React.Fragment>
+	);
 
-			</React.Fragment>
-		);
-
-	}
-
-}
+};
 
 InstanceWrapper.propTypes = {
 	instance: ImmutablePropTypes.map.isRequired,

--- a/src/react/utils/ListWrapper.jsx
+++ b/src/react/utils/ListWrapper.jsx
@@ -4,25 +4,21 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import { List, PageTitle } from '../components';
 
-class ListWrapper extends React.Component {
+const ListWrapper = props => {
 
-	render () {
+	const { pageTitleText, instances } = props;
 
-		const { pageTitleText, instances } = this.props;
+	return (
+		<React.Fragment>
 
-		return (
-			<React.Fragment>
+			<PageTitle text={pageTitleText} />
 
-				<PageTitle text={pageTitleText} />
+			<List instances={instances} />
 
-				<List instances={instances} />
+		</React.Fragment>
+	);
 
-			</React.Fragment>
-		);
-
-	}
-
-}
+};
 
 ListWrapper.propTypes = {
 	pageTitleText: PropTypes.string.isRequired,


### PR DESCRIPTION
As part of the aim to bring all this app's dependencies up-to-date, this PR makes the first step that is a recommended action prior to upgrading React Router (`react-router-dom`) to v6, which is to use the recommended style for >= v5.1 (this app currently uses `^5.1.2`) as described [here](https://reactrouter.com/en/v6.3.0/upgrading/v5#upgrade-to-react-router-v51).

This includes:
- Replacing `<Route render>` with `<Route children>`
- Introduction of [React hooks](https://reactjs.org/docs/hooks-intro.html)

Checks were made to ensure that there were no regressions to the issue previously fixed in the below PR:
- https://github.com/andygout/theatrebase-spa/pull/48

Equivalent changes were applied to [theatrebase-cms](https://github.com/andygout/theatrebase-cms) in https://github.com/andygout/theatrebase-cms/pull/179

### References:
- [React Router: Upgrading from v5](https://reactrouter.com/en/v6.3.0/upgrading/v5)
- [React: Introducing Hooks](https://reactjs.org/docs/hooks-intro.html)
- [React: Building Your Own Hooks](https://reactjs.org/docs/hooks-custom.html)
- [Stack Overflow: javascript - componentDidMount equivalent on a React function/Hooks component?](https://stackoverflow.com/questions/53945763/componentdidmount-equivalent-on-a-react-function-hooks-component#answer-54655508)
  - > Suggests that `useEffect(() => { // Your code here }, []);` is equivalent to `componentDidMount`, which is not strictly true - see following reference links 
- [React Training: useEffect(fn, []) is not the new componentDidMount()](https://reacttraining.com/blog/useEffect-is-not-the-new-componentDidMount/#:~:text=componentDidMount%20and%20useEffect%20run%20after,state%20to%20make%20new%20UI)
  - > `componentDidMount` and `useEffect` run after the mount. However `useEffect` runs **after the paint** has been committed to the screen as opposed to before. This means you would get a flicker if you needed to read from the DOM, then synchronously set state to make new UI.
  - The above is not an issue in the case of this app, though it was for [theatrebase-cms](https://github.com/andygout/theatrebase-cms) - see https://github.com/andygout/theatrebase-cms/pull/179