### PR TITLE
Upgrade react-router-dom ^5.1.2 -> ^6.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "react-helmet": "^6.0.0",
     "react-immutable-proptypes": "^2.2.0",
     "react-redux": "^7.2.0",
-    "react-router-dom": "^5.1.2",
+    "react-router-dom": "^6.4.1",
     "redux": "^4.1.2",
     "redux-immutable": "^4.0.0",
     "redux-logger": "^3.0.6",

--- a/src/react/App.jsx
+++ b/src/react/App.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Switch, useLocation } from 'react-router-dom';
+import { Route, Routes, useLocation } from 'react-router-dom';
 
 import routes from './routes';
 import { FetchDataOnMountWrapper } from './utils';
@@ -9,7 +9,7 @@ const App = () => {
 	const location = useLocation();
 
 	return (
-		<Switch>
+		<Routes>
 			{
 				routes.map((route, index) => {
 					const RouteComponent = route.component;
@@ -18,20 +18,21 @@ const App = () => {
 						<Route
 							key={index}
 							path={route.path}
-							exact={route.exact}
-						>
-							<FetchDataOnMountWrapper
-								documentTitle={route.documentTitle}
-								fetchData={route.fetchData}
-								key={location.key}
-							>
-								<RouteComponent />
-							</FetchDataOnMountWrapper>
-						</Route>
+							element={
+								<FetchDataOnMountWrapper
+									key={location.pathname}
+									path={route.path}
+									documentTitle={route.documentTitle}
+									fetchData={route.fetchData}
+								>
+									<RouteComponent />
+								</FetchDataOnMountWrapper>
+							}
+						/>
 					);
 				})
 			}
-		</Switch>
+		</Routes>
 	);
 
 };

--- a/src/react/react-html.jsx
+++ b/src/react/react-html.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { Provider } from 'react-redux';
-import { StaticRouter } from 'react-router-dom';
+import { StaticRouter } from 'react-router-dom/server';
 
 import App from './App';
 

--- a/src/react/routes.js
+++ b/src/react/routes.js
@@ -26,7 +26,6 @@ import { MODELS, PLURALISED_MODELS } from '../utils/constants';
 export default [
 	{
 		path: '/',
-		exact: true,
 		documentTitle: () => 'Home',
 		component: Home,
 		fetchData: [
@@ -35,7 +34,6 @@ export default [
 	},
 	{
 		path: '/awards/ceremonies',
-		exact: true,
 		documentTitle: () => 'Award ceremonies',
 		component: AwardCeremonies,
 		fetchData: [
@@ -54,7 +52,6 @@ export default [
 	},
 	{
 		path: '/awards',
-		exact: true,
 		documentTitle: () => 'Awards',
 		component: Awards,
 		fetchData: [
@@ -73,7 +70,6 @@ export default [
 	},
 	{
 		path: '/characters',
-		exact: true,
 		documentTitle: () => 'Characters',
 		component: Characters,
 		fetchData: [
@@ -92,7 +88,6 @@ export default [
 	},
 	{
 		path: '/companies',
-		exact: true,
 		documentTitle: () => 'Companies',
 		component: Companies,
 		fetchData: [
@@ -111,7 +106,6 @@ export default [
 	},
 	{
 		path: '/materials',
-		exact: true,
 		documentTitle: () => 'Materials',
 		component: Materials,
 		fetchData: [
@@ -130,7 +124,6 @@ export default [
 	},
 	{
 		path: '/people',
-		exact: true,
 		documentTitle: () => 'People',
 		component: People,
 		fetchData: [
@@ -149,7 +142,6 @@ export default [
 	},
 	{
 		path: '/productions',
-		exact: true,
 		documentTitle: () => 'Productions',
 		component: Productions,
 		fetchData: [
@@ -168,7 +160,6 @@ export default [
 	},
 	{
 		path: '/venues',
-		exact: true,
 		documentTitle: () => 'Venues',
 		component: Venues,
 		fetchData: [

--- a/src/react/utils/FetchDataOnMountWrapper.jsx
+++ b/src/react/utils/FetchDataOnMountWrapper.jsx
@@ -3,15 +3,15 @@ import React, { useEffect } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
-import { useRouteMatch } from 'react-router-dom';
+import { useMatch } from 'react-router-dom';
 
 import { ErrorMessage, Footer, Header, Navigation } from '../components';
 
 const FetchDataOnMountWrapper = props => {
 
-	const { documentTitle, error, children } = props;
+	const { path, documentTitle, error, children } = props;
 
-	const match = useRouteMatch();
+	const match = useMatch(path);
 
 	useEffect(() => {
 
@@ -52,6 +52,7 @@ const FetchDataOnMountWrapper = props => {
 };
 
 FetchDataOnMountWrapper.propTypes = {
+	path: PropTypes.string.isRequired,
 	documentTitle: PropTypes.func.isRequired,
 	error: ImmutablePropTypes.map.isRequired,
 	children: PropTypes.node.isRequired,

--- a/src/server/router.js
+++ b/src/server/router.js
@@ -28,7 +28,7 @@ router.get('*', async (request, response, next) => {
 
 		routes.some(route => {
 
-			const match = matchPath(request.url, route);
+			const match = matchPath(route, request.url);
 
 			if (match && route.fetchData) {
 				route.fetchData.forEach(fetchDataFunction =>


### PR DESCRIPTION
This PR upgrades React Router (`react-router-dom`) to v6, following the migration guides listed under the References header.

Equivalent changes were applied to [theatrebase-cms](https://github.com/andygout/theatrebase-cms) in https://github.com/andygout/theatrebase-cms/pull/180

### References:
- [React Router: Upgrade to React Router v6](https://reactrouter.com/en/6.4.1/upgrading/v5#upgrade-to-react-router-v6)
- [React Router: Feature Overview v6.4.1](https://reactrouter.com/en/6.4.1/start/overview)