### PR TITLE
Use React Router NavLink in InstanceLink component

### DIFF
--- a/src/client/stylesheets/_page.scss
+++ b/src/client/stylesheets/_page.scss
@@ -26,6 +26,14 @@ a {
 	&:hover {
 		color: color-variables.$default-text-color;
 	}
+
+	&.active {
+		color: color-variables.$default-text-color;
+
+		&:hover {
+			cursor: auto;
+		}
+	}
 }
 
 .page-container {

--- a/src/react/components/CommaSeparatedInstanceLinks.jsx
+++ b/src/react/components/CommaSeparatedInstanceLinks.jsx
@@ -15,11 +15,7 @@ const CommaSeparatedInstanceLinks = props => {
 					.map((instance, index) =>
 						<React.Fragment key={index}>
 
-							{
-								instance.uuid
-									? <InstanceLink key={index} instance={instance} />
-									: instance.name
-							}
+							<InstanceLink key={index} instance={instance} />
 
 						</React.Fragment>
 					)

--- a/src/react/components/InstanceLink.jsx
+++ b/src/react/components/InstanceLink.jsx
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { NavLink } from 'react-router-dom';
 
 import { MODEL_TO_ROUTE_MAP } from '../../utils/constants';
 
@@ -15,9 +15,9 @@ const InstanceLink = props => {
 	const instancePath = `/${MODEL_TO_ROUTE_MAP[model]}/${uuid}`;
 
 	return (
-		<Link to={instancePath}>
+		<NavLink to={instancePath}>
 			{ instance.name }
-		</Link>
+		</NavLink>
 	);
 
 };

--- a/src/react/components/List.jsx
+++ b/src/react/components/List.jsx
@@ -41,11 +41,7 @@ const List = props => {
 							)
 						}
 
-						{
-							instance.uuid
-								? <InstanceLink instance={instance} />
-								: instance.name
-						}
+						<InstanceLink instance={instance} />
 
 						{
 							(instance.format || instance.year) && (

--- a/src/react/components/ProducerEntities.jsx
+++ b/src/react/components/ProducerEntities.jsx
@@ -21,11 +21,7 @@ const ProducerEntities = props => {
 								)
 							}
 
-							{
-								entity.uuid
-									? <InstanceLink instance={entity} />
-									: entity.name
-							}
+							<InstanceLink instance={entity} />
 
 						</React.Fragment>
 					)

--- a/src/react/components/WritingEntities.jsx
+++ b/src/react/components/WritingEntities.jsx
@@ -21,11 +21,7 @@ const WritingEntities = props => {
 								)
 							}
 
-							{
-								entity.uuid
-									? <InstanceLink instance={entity} />
-									: entity.name
-							}
+							<InstanceLink instance={entity} />
 
 							{
 								(entity.format || entity.year) && (


### PR DESCRIPTION
This PR makes changes to accommodate the changes made in this API PR: https://github.com/andygout/theatrebase-api/pull/496

Currently, this app takes the absence of an associated instance's `uuid` as a directive that it is the same as the subject instance and to display it as plain text rather than a link, e.g. where William Shakespeare appears as a credited writer or source material writer on his own page:

<img width="893" alt="Screenshot 2022-10-28 at 19 32 58" src="https://user-images.githubusercontent.com/10484515/198710354-d9046b83-db58-453e-8a59-5fea8ff7aeb6.png">

The changes in the API mean that that the `uuid` value will now always be present for associated instances, and so the React Router NavLink component can now instead be used to determine whether or not a link is the same as the current path and handle it accordingly.

### References:
- [React Router: NavLink v6.4.1](https://reactrouter.com/en/main/components/nav-link)
  - > A `<NavLink>` is a special kind of [<Link>](https://reactrouter.com/en/main/components/link) that knows whether or not it is "active". This is useful when building a navigation menu such as a breadcrumb or a set of tabs where you'd like to show which of them is currently selected. It also provides useful context for assistive technology like screen readers.