### PR TITLE
Prevent displaying static text as links

### DIFF
--- a/src/react/components/List.jsx
+++ b/src/react/components/List.jsx
@@ -47,7 +47,11 @@ const List = props => {
 							)
 						}
 
-						<InstanceLink instance={instance} />
+						{
+							instance.uuid
+								? <InstanceLink instance={instance} />
+								: instance.name
+						}
 
 						{
 							(instance.format || instance.year) && (


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/andygout/theatrebase-spa/pull/165 whereby values intended as static text where being displayed as links (to `/undefined/undefined`).

#### Before

<img width="305" alt="before" src="https://user-images.githubusercontent.com/10484515/208299592-1a90847d-898e-483e-be34-91673f7a7851.png">

---

#### After

<img width="299" alt="after" src="https://user-images.githubusercontent.com/10484515/208299597-3f13a8e1-a0a4-4874-a7d6-028c38170c22.png">