### PR TITLE
Apply WritingEntities component separator conditions

### DIFF
--- a/src/react/components/WritingEntities.jsx
+++ b/src/react/components/WritingEntities.jsx
@@ -43,7 +43,25 @@ const WritingEntities = props => {
 
 						</React.Fragment>
 					)
-					.reduce((prev, curr) => [prev, ', ', curr])
+					.reduce((prev, curr, currentIndex) => {
+
+						let separator = ', ';
+
+						if (entities.length === 2) {
+
+							separator = ' and ';
+
+						} else {
+
+							const isFinalIteration = currentIndex === entities.length - 1;
+
+							if (isFinalIteration) separator = ', and ';
+
+						}
+
+						return [prev, separator, curr];
+
+					})
 			}
 
 		</>


### PR DESCRIPTION
This PR adds conditions to the separator for writing entities so that the credits appear in a more human-readable format.

### Greenland (material)

#### Before:
![Screenshot 2023-01-14 at 15 41 52](https://user-images.githubusercontent.com/10484515/212482547-affc114b-871f-431f-9cae-a3601a7f9e70.png)

#### After:
N.B. Usage of the Oxford comma is a conscious choice.
![Screenshot 2023-01-14 at 15 41 22](https://user-images.githubusercontent.com/10484515/212482554-9d7a2380-538c-455e-a4d5-8106193ae74a.png)

---

### Pravda (material)

#### Before:
![Screenshot 2023-01-14 at 16 13 09](https://user-images.githubusercontent.com/10484515/212482559-3d75b286-5561-491b-8545-00669062384d.png)

#### After:
![Screenshot 2023-01-14 at 16 09 18](https://user-images.githubusercontent.com/10484515/212482564-1dada9da-1a9c-4e4b-980d-7617905862f5.png)