### PR TITLE
Remove sur-material prefix from material instance page title

### DIFF
--- a/src/lib/get-instance-title.js
+++ b/src/lib/get-instance-title.js
@@ -12,10 +12,6 @@ export default instance => {
 			if (instance.award) title = `${instance.award.name} ${title}`;
 			return title;
 
-		case MODELS.MATERIAL:
-			if (instance.surMaterial) title = `${instance.surMaterial.name}: ${title}`;
-			return title;
-
 		case MODELS.VENUE:
 			if (instance.surVenue) title = `${instance.surVenue.name}: ${title}`;
 			return title;


### PR DESCRIPTION
When sur-sur-materials are introduced, the page titles will become increasingly unwieldy and unreadable, e.g.

**Material instance:** From Elsewhere: The Message…
**Sur-material:** First Blast: Proliferation (1940-1992)
**Sur-sur-material:** The Bomb: A Partial History

This produces:

The Bomb: A Partial History: First Blast: Proliferation (1940-1992): From Elsewhere: The Message…

The collection(s) of which a sub-material is part already appear elsewhere on the material instance page (under the "Part of" header) so it can be argued that it is unnecessary to repeat this information as part of the page title and also that it de-emphasises that the sub-material should be considered as a discrete work in its own right.