### PR TITLE
Display material sub-sub-materials

### DIFF
--- a/src/client/stylesheets/_list.scss
+++ b/src/client/stylesheets/_list.scss
@@ -1,5 +1,9 @@
 .list {
 	list-style: disc inside;
+
+	& .list--nested {
+		margin-left: 20px;
+	}
 }
 
 .list--no-bullets {

--- a/src/react/components/ListWrapper.jsx
+++ b/src/react/components/ListWrapper.jsx
@@ -3,10 +3,10 @@ import React from 'react';
 
 const ListWrapper = props => {
 
-	const { children } = props;
+	const { isNested, children } = props;
 
 	return (
-		<ul className="list">
+		<ul className={isNested ? 'list--nested' : 'list'}>
 
 			{ children }
 
@@ -16,6 +16,7 @@ const ListWrapper = props => {
 };
 
 ListWrapper.propTypes = {
+	isNested: PropTypes.bool,
 	children: PropTypes.node.isRequired
 };
 

--- a/src/react/components/MaterialLinkWithContext.jsx
+++ b/src/react/components/MaterialLinkWithContext.jsx
@@ -11,6 +11,12 @@ const MaterialLinkWithContext = props => {
 		<>
 
 			{
+				material.surMaterial?.surMaterial && (
+					<PrependedSurInstance surInstance={material.surMaterial.surMaterial} />
+				)
+			}
+
+			{
 				material.surMaterial && (
 					<PrependedSurInstance surInstance={material.surMaterial} />
 				)

--- a/src/react/components/MaterialsList.jsx
+++ b/src/react/components/MaterialsList.jsx
@@ -5,16 +5,22 @@ import { ListWrapper, MaterialLinkWithContext } from '.';
 
 const MaterialsList = props => {
 
-	const { materials } = props;
+	const { materials, isNested } = props;
 
 	return (
-		<ListWrapper>
+		<ListWrapper isNested={isNested}>
 
 			{
 				materials.map((material, index) =>
 					<li key={index}>
 
 						<MaterialLinkWithContext material={material} />
+
+						{
+							material.subMaterials?.length > 0 && (
+								<MaterialsList materials={material.subMaterials} isNested={true} />
+							)
+						}
 
 					</li>
 				)
@@ -26,7 +32,8 @@ const MaterialsList = props => {
 };
 
 MaterialsList.propTypes = {
-	materials: PropTypes.array.isRequired
+	materials: PropTypes.array.isRequired,
+	isNested: PropTypes.bool
 };
 
 export default MaterialsList;

--- a/src/react/components/WritingEntities.jsx
+++ b/src/react/components/WritingEntities.jsx
@@ -16,6 +16,12 @@ const WritingEntities = props => {
 						<React.Fragment key={index}>
 
 							{
+								entity.surMaterial?.surMaterial && (
+									<PrependedSurInstance surInstance={entity.surMaterial.surMaterial} />
+								)
+							}
+
+							{
 								entity.surMaterial && (
 									<PrependedSurInstance surInstance={entity.surMaterial} />
 								)


### PR DESCRIPTION
Display material sub-sub-materials exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/519.

---

## Real-life examples

#### The Bomb: A Partial History (collection of plays) (material)
<img width="596" alt="the-bomb-a-partial-history-material" src="https://user-images.githubusercontent.com/10484515/221379768-a46c8be7-955e-4f89-b4a3-58e3975bf406.png">

---

#### First Blast: Proliferation (sub-collection of plays) (material)
<img width="606" alt="first-blast-proliferation-1940-1992-material" src="https://user-images.githubusercontent.com/10484515/221429298-02f164e1-c2ae-473c-a097-624d66e84874.png">

---

#### From Elsewhere: The Message… (play) (material)
<img width="592" alt="from-elsewhere-the-message-material" src="https://user-images.githubusercontent.com/10484515/221429359-dae6de7f-be46-4769-94d7-b34465897e38.png">

---

#### Zinnie Harris (person)
<img width="859" alt="zinnie-harris-person" src="https://user-images.githubusercontent.com/10484515/221379927-67ca543c-00cd-4064-b326-440fc2ebfe28.png">

---

#### Rudolf (character)
<img width="866" alt="rudolf-character" src="https://user-images.githubusercontent.com/10484515/221379945-030b2802-e0c5-4489-b285-86be6c2d620f.png">

---

#### From Elsewhere: The Message… at Tricycle Theatre (production)
<img width="847" alt="from-elsewhere-on-the-watch-production" src="https://user-images.githubusercontent.com/10484515/221379964-278a89b6-8763-4f7a-8594-5d34a216ab78.png">

---

#### Materials list
<img width="935" alt="materials-list" src="https://user-images.githubusercontent.com/10484515/221379981-8393ad87-6866-4ed4-b865-9e2c4362c8b2.png">

---

## Test examples

### `award-ceremonies-with-crediting-sub-sub-materials.test.js`

#### Wordsmith Award 2010 (award ceremony)
<img width="938" alt="wordsmith-award-2010-award-ceremony" src="https://user-images.githubusercontent.com/10484515/221435826-e958f38e-6a79-47e1-86ed-f79ee91a58ed.png">

---

#### Playwriting Prize 2009 (award ceremony)
<img width="938" alt="playwriting-prize-2009-award-ceremony" src="https://user-images.githubusercontent.com/10484515/221435836-8f378402-253e-4dc7-b37b-035db19aee03.png">

---

#### Dramatists Medal 2008 (award ceremony)
<img width="951" alt="dramatists-medal-2008-award-ceremony" src="https://user-images.githubusercontent.com/10484515/221435866-7c12812e-351c-44c9-84bb-fc35df13df73.png">

---

#### John Doe (person): credit for directly nominated material
<img width="943" alt="john-doe-person" src="https://user-images.githubusercontent.com/10484515/221435875-573f71a9-b329-4149-adf1-6f26cde369ad.png">

---

#### Playwrights Ltd (company): credit for directly nominated material
<img width="941" alt="playwrights-ltd-company" src="https://user-images.githubusercontent.com/10484515/221435887-8f483b1d-eb19-459d-9487-7bed30eca03c.png">

---

#### Sub-Plugh (play, 1899) (material): subsequent versions have nominations
<img width="936" alt="sub-plugh-material" src="https://user-images.githubusercontent.com/10484515/221435896-abf87416-c4d4-435d-8ad7-02262bc36357.png">

---

#### Mid-Plugh (sub-collection of plays, 1899) (material): subsequent versions have nominations
<img width="951" alt="mid-plugh-material" src="https://user-images.githubusercontent.com/10484515/221435930-ffa551cb-7c4f-4f97-981e-e969186a4666.png">

---

#### Sur-Plugh (collection of plays, 1899) (material): subsequent versions have nominations
<img width="940" alt="sur-plugh-material" src="https://user-images.githubusercontent.com/10484515/221435911-12fc8354-d693-44af-b754-bec9dc727e9e.png">

---

#### Francis Flob (person): subsequent versions of their work have nominations
<img width="939" alt="francis-flob-person" src="https://user-images.githubusercontent.com/10484515/221435951-0780fce7-a368-45aa-8234-c720b45b09e3.png">

---

#### Curtain Up Ltd (company): subsequent versions of their work have nominations
<img width="942" alt="curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/221435957-23029fdd-6c18-4543-a1e2-4c4debf5248d.png">

---

#### Sub-Waldo (novel, 1974) (material): materials that used it as source material have nominations
<img width="928" alt="sub-waldo-material" src="https://user-images.githubusercontent.com/10484515/221435962-c0c2fc60-8f58-4236-989c-f00ea4b4e856.png">

---

#### Mid-Waldo (sub-trilogy of novels, 1974) (material): materials that used it as source material have nominations
<img width="937" alt="mid-waldo-material" src="https://user-images.githubusercontent.com/10484515/221435998-0a008255-eab8-4646-b145-dc00f5c2feb3.png">

---

#### Sur-Waldo (trilogy of novels, 1974) (material): materials that used it as source material have nominations
<img width="942" alt="sur-waldo-material" src="https://user-images.githubusercontent.com/10484515/221436005-cae67491-d831-4169-9cde-cd4541d0c021.png">

---

#### Jane Roe (person): materials that used their (specific) work as source material have nominations
<img width="937" alt="jane-roe-person" src="https://user-images.githubusercontent.com/10484515/221436010-2530b9d7-73cf-488f-ae3a-c83bad7fd140.png">

---

#### Fictioneers Ltd (company): materials that used their (specific) work as source material have nominations
<img width="933" alt="fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/221436017-5e425e49-0e93-4005-aa8f-14d7889224f2.png">

---

#### Talyse Tata (person): materials to which they have granted rights have nominations
<img width="944" alt="talyse-tata-person" src="https://user-images.githubusercontent.com/10484515/221436022-59cd4c03-63d9-462c-adda-30eca0997c7e.png">

---

#### Cinerights Ltd (company): materials to which they granted rights have nominations
<img width="952" alt="cinerights-ltd-company" src="https://user-images.githubusercontent.com/10484515/221436026-0d761a8d-c2df-4e55-ba8a-987cc5d74cd6.png">

---

### `award-ceremonies-with-sub-sub-materials-sub-sub-prods.test.js`

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="934" alt="laurence-olivier-awards-2020-award-ceremony" src="https://user-images.githubusercontent.com/10484515/221436809-40d2d197-7169-4fcc-a916-24c2bd7c98f1.png">

---

#### Evening Standard Theatre Awards 2019 (award ceremony)
<img width="928" alt="evening-standard-theatre-awards-2019-award-ceremony" src="https://user-images.githubusercontent.com/10484515/221436813-8e9e837d-4e01-41d3-a342-70f1b3746759.png">

---

#### Critics Circle Theatre Awards 2018 (award ceremony)
<img width="916" alt="critics-circle-theatre-awards-2018-award-ceremony" src="https://user-images.githubusercontent.com/10484515/221436839-02d2b0af-6532-476c-8b28-939080a19fab.png">

---

#### Conor Corge (person)
<img width="949" alt="conor-corge-person" src="https://user-images.githubusercontent.com/10484515/221436845-4eec50f6-74bc-47e0-9146-661d69d32c5b.png">

---

#### Stagecraft Ltd (company)
<img width="946" alt="stagecraft-ltd-company" src="https://user-images.githubusercontent.com/10484515/221436849-d5ffe24f-b6e3-4896-a777-4b7648cdca3d.png">

---

#### Ferdinand Foo (person)
<img width="950" alt="ferdinand-foo-person" src="https://user-images.githubusercontent.com/10484515/221436857-4f4c260e-4f70-4a45-9d58-61b4a459d2d1.png">

---

#### Sub-Hoge at Noël Coward Theatre (production)
<img width="931" alt="sub-hoge-at-noel-coward-theatre-production" src="https://user-images.githubusercontent.com/10484515/221436896-2170596b-6101-4a0e-a1bc-76b77b63d3b6.png">

---

#### Mid-Hoge at Noël Coward Theatre (production)
<img width="941" alt="mid-hoge-at-noel-coward-theatre-production" src="https://user-images.githubusercontent.com/10484515/221436900-c8627c26-3a3f-42bf-9733-5375894ce462.png">

---

#### Sur-Hoge at Noël Coward Theatre (production)
<img width="945" alt="sur-hoge-at-noel-coward-theatre-production" src="https://user-images.githubusercontent.com/10484515/221436905-682d225c-aceb-45ea-9fab-fc009eaf240e.png">

---

#### Sub-Wibble at Royal Court Theatre: Jerwood Theatre Upstairs (production)
<img width="939" alt="sub-wibble-at-royal-court-theatre-jerwood-theatre-upstairs-production" src="https://user-images.githubusercontent.com/10484515/221436956-0a177a4d-7dd7-4023-8ecc-65376e26a767.png">

---

#### Mid-Wibble at Royal Court Theatre: Jerwood Theatre Upstairs (production)
<img width="941" alt="mid-wibble-at-royal-court-theatre-jerwood-theatre-upstairs-production" src="https://user-images.githubusercontent.com/10484515/221436958-b8df6ab4-cb8e-490d-977b-844d7fe4f906.png">

---

#### Sur-Wibble at Royal Court Theatre: Jerwood Theatre Upstairs (production)
<img width="937" alt="sur-wibble-at-royal-court-theatre-jerwood-theatre-upstairs-production" src="https://user-images.githubusercontent.com/10484515/221436961-72fa4a3d-8722-4364-8656-5ff1892be46c.png">

---

#### Sub-Wibble (play) (material)
<img width="944" alt="sub-wibble-material" src="https://user-images.githubusercontent.com/10484515/221436978-60c3236b-abe2-4bf2-9540-669f77871e4d.png">

---

#### Mid-Wibble (play) (material)
<img width="938" alt="mid-wibble-material" src="https://user-images.githubusercontent.com/10484515/221436983-bc42bc82-be2b-4cd2-a020-64c3680b09e1.png">

---

#### Sur-Wibble (trilogy of plays) (material)
<img width="953" alt="sur-wibble-material" src="https://user-images.githubusercontent.com/10484515/221436987-425b570a-2abd-4584-83e4-fc1f152f6fec.png">

---

### `material-with-sub-sub-materials-rights-grantor.test.js`

#### The Tolkien Estate (company)
<img width="937" alt="the-tolkien-estate-company" src="https://user-images.githubusercontent.com/10484515/221437204-797ddbf4-2419-4e56-a559-5dbfcf498a86.png">

---

#### Baillie Tolkien (person)
<img width="938" alt="baillie-tolkien-person" src="https://user-images.githubusercontent.com/10484515/221437202-6bf132d0-d5a4-4df9-8cad-cb0a6785ff35.png">

---

### `material-with-sub-sub-materials-source-materials.test.js`

#### Genesis (religious text) (material)
<img width="925" alt="genesis-material" src="https://user-images.githubusercontent.com/10484515/221437538-f23159b3-58f7-455e-9cc6-66a7c78d6d8a.png">

---

#### Godblog (play) (material)
<img width="942" alt="godblog-material" src="https://user-images.githubusercontent.com/10484515/221437545-2cb5e719-bde0-4574-8120-f0f693c9bcd7.png">

---

#### Richard Bancroft (person)
<img width="937" alt="richard-bancroft-person" src="https://user-images.githubusercontent.com/10484515/221437547-618e72ce-c00f-46d8-93ea-d4826788b465.png">

---

#### Jeanette Winterson (person)
<img width="936" alt="jeanette-winterson-person" src="https://user-images.githubusercontent.com/10484515/221437553-d2cd59bb-c6c1-4824-9d4d-b19a40f4c8d8.png">

---

#### The Canterbury Editors (company)
<img width="936" alt="the-canterbury-editors-company" src="https://user-images.githubusercontent.com/10484515/221437562-360ba03b-7296-4937-9b0a-37e3b3838d98.png">

---

#### Only Fruits (company)
<img width="928" alt="only-fruits-company" src="https://user-images.githubusercontent.com/10484515/221437564-76fad8de-0ecc-46d8-ab1f-0874aaef2970.png">

---

#### Godblog at Bush Theatre (production)
<img width="919" alt="godblog-at-bush-theatre-production" src="https://user-images.githubusercontent.com/10484515/221437567-1e22bc80-3961-4137-8259-9a1ab8d1fa7e.png">

---

#### God (character)
<img width="923" alt="god-character" src="https://user-images.githubusercontent.com/10484515/221437570-2a462240-570e-467c-b757-54eca650be2e.png">

---

#### Materials list
<img width="924" alt="materials-list" src="https://user-images.githubusercontent.com/10484515/221437574-f1dd3663-7370-4afb-8cbe-d9a5ccb0631a.png">

---

### `material-with-sub-sub-materials-subsequent-versions.test.js`

#### Richard II (original version) (material)
<img width="837" alt="richard-ii-original-version-material" src="https://user-images.githubusercontent.com/10484515/221437790-4994a891-b047-4a17-9cba-aadc9d1db385.png">

---

#### Richard II (subsequent version) (material)
<img width="916" alt="richard-ii-subsequent-version-material" src="https://user-images.githubusercontent.com/10484515/221437792-6953f2d9-aa2d-4c2a-8737-51bb9e2a745f.png">

---

#### William Shakespeare (person)
<img width="914" alt="william-shakespeare-person" src="https://user-images.githubusercontent.com/10484515/221437797-760fce72-c1b1-4ecd-a24c-e9c3ee973e30.png">

---

#### The King's Men (company)
<img width="912" alt="the-kings-men-company" src="https://user-images.githubusercontent.com/10484515/221437799-75b1a3c8-5c79-400b-a0b9-29eee1385e6a.png">

---

### `material-with-sub-sub-materials.test.js`

#### The Great Game: Afghanistan (material with sub-sub-materials)
<img width="640" alt="the-great-game-afghanistan-material" src="https://user-images.githubusercontent.com/10484515/221438128-4a78ed22-0122-4740-b1b7-044365191eff.png">

---

#### Part One - Invasions and Independence 1842-1930 (material with sur-material and sub-material)
<img width="818" alt="part-one-invasions-and-independence-1842-1930-material" src="https://user-images.githubusercontent.com/10484515/221438170-a4fadb6f-9e6b-47a2-9844-367cf94aedbb.png">

---

#### Bugles at the Gates of Jalalabad (material with sur-sur-material)
<img width="705" alt="bugles-at-the-gate-of-jalalbad-material" src="https://user-images.githubusercontent.com/10484515/221438244-98f58841-2f91-4f07-9499-a0d6fd7bef73.png">

---

#### Bar (character)
<img width="935" alt="bar-character" src="https://user-images.githubusercontent.com/10484515/221438252-f6c19618-3602-4dd2-ac8d-bdf37f7eb7d3.png">

---

#### The Great Game: Afghanistan at Tricycle Theatre (production)
<img width="511" alt="the-great-game-afghanistan-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/221438288-9598dc60-eef7-48e4-9834-b8f382e109fb.png">

---

#### Part One - Invasions and Independence 1842-1930 at Tricycle Theatre (production)
<img width="819" alt="part-one-invasions-and-independence-1842-1930-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/221438310-971324d1-583f-4e80-a62d-af9595776bd7.png">

---

#### Bugles at the Gates of Jalalabad at Tricycle Theatre (production)
<img width="919" alt="bugles-at-the-gate-of-jalalbad-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/221438361-9eafd2ac-64c9-436c-9f61-9e0cd42d462c.png">

---

#### Ferdinand Foo (person)
<img width="931" alt="ferdinand-foo-person" src="https://user-images.githubusercontent.com/10484515/221438373-c2395af9-3495-4a02-9fd6-3e72b6f43f91.png">

---

#### Fictioneers Ltd (company)
<img width="935" alt="fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/221438380-07a0f22d-4c05-4972-96a8-071636d2a65d.png">

---

#### Materials list
<img width="947" alt="material-list" src="https://user-images.githubusercontent.com/10484515/221438389-820cb115-88cc-4b92-a63c-0ba4a2d89b30.png">