### PR TITLE
Display production sub-sub-productions

### DIFF
--- a/src/react/components/ProductionLinkWithContext.jsx
+++ b/src/react/components/ProductionLinkWithContext.jsx
@@ -11,6 +11,12 @@ const ProductionLinkWithContext = props => {
 		<>
 
 			{
+				production.surProduction?.surProduction && (
+					<PrependedSurInstance surInstance={production.surProduction.surProduction} />
+				)
+			}
+
+			{
 				production.surProduction && (
 					<PrependedSurInstance surInstance={production.surProduction} />
 				)

--- a/src/react/components/ProductionsList.jsx
+++ b/src/react/components/ProductionsList.jsx
@@ -5,16 +5,22 @@ import { ListWrapper, ProductionLinkWithContext } from '.';
 
 const ProductionsList = props => {
 
-	const { productions } = props;
+	const { productions, isNested } = props;
 
 	return (
-		<ListWrapper>
+		<ListWrapper isNested={isNested}>
 
 			{
 				productions.map((production, index) =>
 					<li key={index}>
 
 						<ProductionLinkWithContext production={production} />
+
+						{
+							production.subProductions?.length > 0 && (
+								<ProductionsList productions={production.subProductions} isNested={true} />
+							)
+						}
 
 					</li>
 				)
@@ -26,7 +32,8 @@ const ProductionsList = props => {
 };
 
 ProductionsList.propTypes = {
-	productions: PropTypes.array.isRequired
+	productions: PropTypes.array.isRequired,
+	isNested: PropTypes.bool
 };
 
 export default ProductionsList;


### PR DESCRIPTION
Display material sub-sub-materials exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/520.

---

## Real-life examples

#### The Bomb: A Partial History at Tricycle Theatre (production)
<img width="614" alt="the-bomb-a-partial-history-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/222929502-8c18ae68-1653-4686-a809-7d98e0357827.png">

---

#### First Blast: Proliferation (1940-1992) at Tricycle Theatre (production)
<img width="597" alt="first-blast-proliferation-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/222929505-a1f0c5db-8143-4cd9-afbb-5f06cf536108.png">

---

#### From Elsewhere: The Message… at Tricycle Theatre (production)
<img width="802" alt="from-elsewhere-the-message-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/222929506-ff1d38cb-8ed3-4e99-acd5-64967900f06c.png">

---

#### From Elsewhere: The Message… (play) (material)
<img width="928" alt="from-elsewhere-the-message-material" src="https://user-images.githubusercontent.com/10484515/222929511-353e7656-a675-4468-9517-a844704f8379.png">

---

#### Tricycle Theatre (venue)
<img width="895" alt="tricycle-theatre-venue" src="https://user-images.githubusercontent.com/10484515/222929458-f2d01425-d5c0-4394-b068-3f778800741a.png">

---

#### Tricycle Theatre Company (company)
<img width="949" alt="tricycle-theatre-company" src="https://user-images.githubusercontent.com/10484515/222929453-746b9e15-ebd6-4353-ac29-bd88cfd4f5d5.png">

---

#### Rudolf (character)
<img width="942" alt="rudolf-character" src="https://user-images.githubusercontent.com/10484515/222929446-34dce012-e443-4be5-8e53-3ec17011e6cd.png">

---

#### Rick Warden (person)
<img width="941" alt="rick-warden-person" src="https://user-images.githubusercontent.com/10484515/222929444-24c8ea75-e90e-4714-9d64-93f231768954.png">

---

#### Nicolas Kent (person)
<img width="949" alt="nicolas-kent-person" src="https://user-images.githubusercontent.com/10484515/222929441-b7c7ac7e-0134-4e2d-8f42-f87fa5b3bc6e.png">

---

#### Productions list
<img width="947" alt="productions-list" src="https://user-images.githubusercontent.com/10484515/222929432-64b1f511-3ac3-4de0-9766-04122288d170.png">

---

## Test examples

### `award-ceremonies-with-crediting-sub-sub-materials.test.js`

#### Wordsmith Award 2010 (award ceremony)
<img width="933" alt="wordsmith-award-2010-award-ceremony" src="https://user-images.githubusercontent.com/10484515/222930490-56fd27e3-f3fb-49f6-85b9-45a1c4ae1ca1.png">

---

#### John Doe (person): credit for directly nominated material
<img width="938" alt="john-doe-person" src="https://user-images.githubusercontent.com/10484515/222930494-6271bcb1-df5b-4038-821f-14fe49c803d7.png">

---

#### Playwrights Ltd (company): credit for directly nominated material
<img width="942" alt="playwrights-ltd-company" src="https://user-images.githubusercontent.com/10484515/222930495-868e714c-77ad-4b54-94ca-4ae2ba05d7a8.png">

---

#### Sub-Plugh (play, 1899) (material): subsequent versions have nominations
<img width="934" alt="sub-plugh-original-material" src="https://user-images.githubusercontent.com/10484515/222930497-08014a3f-f1b5-4ddc-b3db-a674bf858b68.png">

---

#### Mid-Plugh (sub-collection of plays, 1899) (material): subsequent versions have nominations
<img width="932" alt="mid-plugh-original-material" src="https://user-images.githubusercontent.com/10484515/222930513-60f1f653-6615-4a42-9f5a-4479772c0398.png">

---

#### Sur-Plugh (collection of plays, 1899) (material): subsequent versions have nominations
<img width="925" alt="sur-plugh-original-material" src="https://user-images.githubusercontent.com/10484515/222930515-655e12f4-5225-4281-a37b-c37914f5866b.png">

---

#### Francis Flob (person): subsequent versions of their work have nominations
<img width="925" alt="francis-flob-person" src="https://user-images.githubusercontent.com/10484515/222930518-a0d8f7cb-130a-4f92-9a4a-7bca89bd4f09.png">

---

#### Curtain Up Ltd (company): subsequent versions of their work have nominations
<img width="922" alt="curtain-up-ltd-company" src="https://user-images.githubusercontent.com/10484515/222930520-ac0fb51e-f86b-4fc3-997a-4c8f4eaf6a9e.png">

---

#### Sub-Waldo (novel, 1974) (material): materials that used it as source material have nominations
<img width="940" alt="sub-waldo-material" src="https://user-images.githubusercontent.com/10484515/222930526-63c35045-98ce-417d-80e9-effced771b4e.png">

---

#### Mid-Waldo (sub-trilogy of novels, 1974) (material): materials that used it as source material have nominations
<img width="921" alt="mid-waldo-material" src="https://user-images.githubusercontent.com/10484515/222930528-2149b0d4-b339-40ee-bd96-370810c3f655.png">

---

#### Sur-Waldo (trilogy of trilogies of novels, 1974) (material): materials that used it as source material have nominations
<img width="946" alt="sur-waldo-material" src="https://user-images.githubusercontent.com/10484515/222933638-e5cc9489-b1f3-451e-9e11-33377b0bed6c.png">

---

#### Jane Roe (person): materials that used their (specific) work as source material have nominations
<img width="935" alt="jane-roe-person" src="https://user-images.githubusercontent.com/10484515/222930558-3d523b46-e4c1-4891-9d23-42e38c4071e8.png">

---

#### Fictioneers Ltd (company): materials that used their (specific) work as source material have nominations
<img width="928" alt="fictioneers-ltd-company" src="https://user-images.githubusercontent.com/10484515/222930562-3687cb2e-7370-4064-9452-7fa79a124c76.png">

---

#### Talyse Tata (person): materials to which they have granted rights have nominations
<img width="938" alt="talyse-tata-person" src="https://user-images.githubusercontent.com/10484515/222930566-86ca98b3-41c3-4d23-973f-07dac2497a7f.png">

---

#### Cinerights Ltd (company): materials to which they granted rights have nominations
<img width="937" alt="cinerights-ltd-company" src="https://user-images.githubusercontent.com/10484515/222930567-445f6e7e-5866-4fe8-a4b3-bb986f210c0e.png">

---

### `award-ceremonies-with-sub-sub-materials-sub-sub-prods.test.js`

#### Laurence Olivier Awards 2020 (award ceremony)
<img width="939" alt="laurence-olivier-awards-2020-award-ceremony" src="https://user-images.githubusercontent.com/10484515/222931247-684f0616-a497-4ab1-8644-18574abc16e0.png">

---

#### Conor Corge (person)
<img width="942" alt="conor-corge-person" src="https://user-images.githubusercontent.com/10484515/222931252-6eca0049-8e79-4ea1-8dbc-a20905a49bc2.png">

---

#### Stagecraft Ltd (company)
<img width="941" alt="stagecraft-ltd-company" src="https://user-images.githubusercontent.com/10484515/222931255-d307d47b-e094-4e24-91ec-1f4891f2976f.png">

---

#### Ferdinand Foo (person)
<img width="941" alt="ferdinand-foo-person" src="https://user-images.githubusercontent.com/10484515/222931261-df9dc4fb-6271-40f9-a6b9-4aa87e2d13e4.png">

---

#### Sub-Wibble at Jerwood Theatre Upstairs (production)
<img width="932" alt="sub-wibble-at-jerwood-theatre-upstairs-production" src="https://user-images.githubusercontent.com/10484515/222931264-84c34f6e-1ca8-434b-b1bf-c2809cb79339.png">

---

#### Mid-Wibble at Jerwood Theatre Upstairs (production)
<img width="936" alt="mid-wibble-at-jerwood-theatre-upstairs-production" src="https://user-images.githubusercontent.com/10484515/222931265-d6acef18-80c7-46ca-8cc1-051b96ca300a.png">

---

#### Sur-Wibble at Jerwood Theatre Upstairs (production)
<img width="935" alt="sur-wibble-at-jerwood-theatre-upstairs-production" src="https://user-images.githubusercontent.com/10484515/222931271-a87cfb83-2faf-4b7a-99aa-d827781abc06.png">

---

#### Sub-Hoge at Noël Coward Theatre (production)
<img width="943" alt="sub-hoge-at-noël-coward-theatre-production" src="https://user-images.githubusercontent.com/10484515/222931292-aea4c050-48cb-4e67-902a-2f25f66395ef.png">

---

#### Mid-Hoge at Noël Coward Theatre (production)
<img width="945" alt="mid-hoge-at-noël-coward-theatre-production" src="https://user-images.githubusercontent.com/10484515/222931293-d9f04465-de76-4107-9995-286782fedfd7.png">

---

#### Sur-Hoge at Noël Coward Theatre (production)
<img width="943" alt="sur-hoge-at-noël-coward-theatre-production" src="https://user-images.githubusercontent.com/10484515/222931296-eef9f206-2c7f-4586-b156-b00a95f3d80e.png">

---

#### Sub-Wibble (play) (material)
<img width="955" alt="sub-wibble-material" src="https://user-images.githubusercontent.com/10484515/222931298-0522b045-1b1c-49e5-9e6d-410099d1c2a0.png">

---

#### Sub-Wibble (sub-trilogy of plays) (material)
<img width="941" alt="mid-wibble-material" src="https://user-images.githubusercontent.com/10484515/222931302-4566072f-3dd2-41f0-b538-d0cebc827b11.png">

---

#### Sur-Wibble (trilogy of trilogies of plays) (material)
<img width="941" alt="sur-wibble-material" src="https://user-images.githubusercontent.com/10484515/222931307-1f2aacfa-214d-450c-a5c1-514387f0bee7.png">

---

### `material-with-sub-sub-materials-source-materials.test.js`

#### Genesis (religious text) (material)
<img width="933" alt="genesis-material" src="https://user-images.githubusercontent.com/10484515/222931446-c94e326f-7150-4814-8fd8-7f29355f5b62.png">

---

### `prod-with-sub-sub-prods.test.js`

#### The Great Game at Roda Theatre (production with sub-sub-productions that have a sur-venue)
<img width="890" alt="the-great-game-afghanistan-at-roda-theatre-production" src="https://user-images.githubusercontent.com/10484515/222933275-0d46faae-2ec1-41fd-b639-fd37b731e033.png">

---

#### Part One - Invasions and Independence 1842-1930 at Roda Theatre (production with sur-production and sub-productions that have a sur-venue)
<img width="812" alt="part-one-invastions-and-independence-1842-1930-at-roda-theatre-production" src="https://user-images.githubusercontent.com/10484515/222933288-f69ccdf5-1c88-4e20-b1a7-2f10ba23aedc.png">

---

#### Bugles at the Gates of Jalalabad at Roda Theatre (production with sur-production that has a sur-venue)
<img width="923" alt="bugles-at-the-gate-of-jalalabad-at-roda-theatre-production" src="https://user-images.githubusercontent.com/10484515/222933292-dfe2de0d-c405-4700-95b1-1d5e7ddeb72e.png">

---

#### The Great Game at Tricycle Theatre (production with sub-sub-productions that do not have a sur-venue)
<img width="745" alt="the-great-game-afghanistan-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/222933299-d37e0709-3c46-4907-ac71-1693e14eb5ff.png">

---

#### Part One - Invasions and Independence 1842-1930 at Tricycle Theatre (production with sur-production and sub-productions that do not have a sur-venue)
<img width="810" alt="part-one-invastions-and-independence-1842-1930-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/222933302-b2bfc2b8-b0e2-4e8b-a565-014e7e44b10c.png">

---

#### Bugles at the Gates of Jalalabad at Tricycle Theatre (production with sur-production that has a sur-venue)
<img width="809" alt="bugles-at-the-gate-of-jalalabad-at-tricycle-theatre-production" src="https://user-images.githubusercontent.com/10484515/222933305-f133e32c-f4a5-4aad-ab54-cfa73beae2e7.png">

---

#### The Great Game: Afghanistan (material)
<img width="676" alt="the-great-game-afghanistan-material" src="https://user-images.githubusercontent.com/10484515/222933308-3681038b-4a2f-4ece-89c7-41e29e7bd491.png">

---

#### Part One - Invasions and Independence 1842-1930 (material)
<img width="944" alt="part-one-invastions-and-independence-1842-1930-material" src="https://user-images.githubusercontent.com/10484515/222933310-33d08fa3-b2d5-4f08-ae60-644273a1e954.png">

---

#### Bugles at the Gates of Jalalabad (material)
<img width="945" alt="bugles-at-the-gate-of-jalalabad-material" src="https://user-images.githubusercontent.com/10484515/222933313-c470d086-299a-451d-91aa-85109204227e.png">

---

#### Berkeley Repertory Theatre (venue)
<img width="946" alt="berkeley-repertory-theatre-venue" src="https://user-images.githubusercontent.com/10484515/222933316-4436a481-d631-44c4-a043-45d221d61011.png">

---

#### Roda Theatre (venue)
<img width="934" alt="roda-theatre-venue" src="https://user-images.githubusercontent.com/10484515/222933319-7d5df390-d680-46b9-825b-3c77f22f3aba.png">

---

#### Nicolas Kent (person)
<img width="940" alt="nicolas-kent-person" src="https://user-images.githubusercontent.com/10484515/222933320-3746ab8a-aab5-4d65-9d1e-5a5040c6f30c.png">

---

#### Tricycle Theatre Company (company)
<img width="940" alt="tricycle-theatre-company" src="https://user-images.githubusercontent.com/10484515/222933325-46de5c2d-a187-47f7-8fdf-dcd859504257.png">

---

#### Zoë Ingenhaag (person)
<img width="940" alt="zoë-ingenhaag-person" src="https://user-images.githubusercontent.com/10484515/222933327-b7bafa88-2b43-449a-b0d6-903a83b1e775.png">

---

#### Rick Warden (person)
<img width="946" alt="rick-warden-person" src="https://user-images.githubusercontent.com/10484515/222933328-c4cf98f6-e1ce-43c8-90cd-46249d432d44.png">

---

#### Howard Harrison (person)
<img width="946" alt="howard-harrison-person" src="https://user-images.githubusercontent.com/10484515/222933330-470407e0-1783-492f-9ad9-f5b49a82d761.png">

---

#### Lighting Design Ltd (company)
<img width="935" alt="lighting-design-ltd-company" src="https://user-images.githubusercontent.com/10484515/222933334-6754ea5f-3374-466c-82b4-4f962ef1db9a.png">

---

#### Jack Knowles (person)
<img width="940" alt="jack-knowles-person" src="https://user-images.githubusercontent.com/10484515/222933344-263c8da4-0bc4-4bd7-b444-a21ac34f5b3d.png">

---

#### Lizzie Chapman (person)
<img width="939" alt="lizzie-chapman-person" src="https://user-images.githubusercontent.com/10484515/222933347-cffe2769-38cb-40f9-a34e-129e848e4bf6.png">

---

#### Stage Management Ltd (company)
<img width="941" alt="stage-management-ltd-company" src="https://user-images.githubusercontent.com/10484515/222933349-eabab77b-20e7-4d31-bb64-96c33bbf6021.png">

---

#### Charlotte Padgham (person)
<img width="945" alt="charlotte-padgham-person" src="https://user-images.githubusercontent.com/10484515/222933351-eb85dac2-153a-4945-bfe2-dcaa4a93c859.png">

---

#### Bar (character)
<img width="941" alt="bar-character" src="https://user-images.githubusercontent.com/10484515/222933354-81ca0be3-7e5b-4adb-ad53-4b857188defa.png">

---

#### Productions list
<img width="955" alt="productions" src="https://user-images.githubusercontent.com/10484515/222933357-c3a2db90-ca18-4616-a602-34fb03711131.png">