### PR TITLE
Remove redundant subVenue from ProductionLinkWithContext component

### DIFF
--- a/src/react/components/ProductionLinkWithContext.jsx
+++ b/src/react/components/ProductionLinkWithContext.jsx
@@ -31,12 +31,6 @@ const ProductionLinkWithContext = props => {
 			}
 
 			{
-				production.subVenue && (
-					<AppendedVenue venue={production.subVenue} />
-				)
-			}
-
-			{
 				(production.startDate || production.endDate) && (
 					<AppendedProductionDates
 						startDate={production.startDate}


### PR DESCRIPTION
Productions do not have a `subVenue` property; they instead have a `venue` property which contains a `surVenue` property, and so this `AppendedVenue` becomes redundant and so is removed by this PR.