### PR TITLE
Revert "Remove redundant subVenue from ProductionLinkWithContext component"

### DIFF
--- a/src/react/components/ProductionLinkWithContext.jsx
+++ b/src/react/components/ProductionLinkWithContext.jsx
@@ -31,6 +31,12 @@ const ProductionLinkWithContext = props => {
 			}
 
 			{
+				production.subVenue && (
+					<AppendedVenue venue={production.subVenue} />
+				)
+			}
+
+			{
 				(production.startDate || production.endDate) && (
 					<AppendedProductionDates
 						startDate={production.startDate}


### PR DESCRIPTION
Reverts andygout/theatrebase-spa#183

It's not actually redundant: when listing the production credits of a venue with sub-venues, it specifies which of the sub-venues hosted the production.

---

#### Before
<img width="425" alt="before" src="https://user-images.githubusercontent.com/10484515/226477667-61c76cd5-a2dd-49a1-a95b-0f98a832dabd.png">

---

#### After
<img width="523" alt="after" src="https://user-images.githubusercontent.com/10484515/226477684-de18f5d7-4674-4c0a-a92b-ffc40a2fa680.png">