### PR TITLE
Remove redundant ProductionsList component isNested prop type

### DIFF
--- a/src/react/components/ProductionsList.jsx
+++ b/src/react/components/ProductionsList.jsx
@@ -26,8 +26,7 @@ const ProductionsList = props => {
 };
 
 ProductionsList.propTypes = {
-	productions: PropTypes.array.isRequired,
-	isNested: PropTypes.bool
+	productions: PropTypes.array.isRequired
 };
 
 export default ProductionsList;


### PR DESCRIPTION
This PR removes a prop type that should have been removed from the `ProductionsList` component as part of this PR https://github.com/andygout/theatrebase-spa/pull/186.