### PR TITLE
Display festival festival series

### DIFF
--- a/src/lib/get-instance-title.js
+++ b/src/lib/get-instance-title.js
@@ -12,6 +12,10 @@ export default instance => {
 			if (instance.award) title = `${instance.award.name} ${title}`;
 			return title;
 
+		case MODELS.FESTIVAL:
+			if (instance.festivalSeries) title = `${instance.festivalSeries.name} ${title}`;
+			return title;
+
 		case MODELS.VENUE:
 			if (instance.surVenue) title = `${instance.surVenue.name}: ${title}`;
 			return title;

--- a/src/react/components/FestivalLinkWithContext.jsx
+++ b/src/react/components/FestivalLinkWithContext.jsx
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import { InstanceLink, PrependedSurInstance } from '.';
+
+const FestivalLinkWithContext = props => {
+
+	const { festival } = props;
+
+	return (
+		<>
+
+			{
+				festival.festivalSeries && (
+					<PrependedSurInstance surInstance={festival.festivalSeries} />
+				)
+			}
+
+			<InstanceLink instance={festival} />
+
+		</>
+	);
+
+};
+
+FestivalLinkWithContext.propTypes = {
+	festival: PropTypes.object.isRequired
+};
+
+export default FestivalLinkWithContext;

--- a/src/react/components/index.js
+++ b/src/react/components/index.js
@@ -18,6 +18,7 @@ import CreativeProductionsList from './CreativeProductionsList';
 import CrewProductionsList from './CrewProductionsList';
 import Entities from './Entities';
 import ErrorMessage from './ErrorMessage';
+import FestivalLinkWithContext from './FestivalLinkWithContext';
 import Footer from './Footer';
 import Header from './Header';
 import InstanceDocumentTitle from './InstanceDocumentTitle';
@@ -63,6 +64,7 @@ export {
 	CrewProductionsList,
 	Entities,
 	ErrorMessage,
+	FestivalLinkWithContext,
 	Footer,
 	Header,
 	InstanceDocumentTitle,

--- a/src/react/pages/instances/Festival.jsx
+++ b/src/react/pages/instances/Festival.jsx
@@ -2,17 +2,27 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { InstanceFacet, ProductionsList } from '../../components';
+import { InstanceFacet, InstanceLink, ProductionsList } from '../../components';
 import { InstancePageWrapper } from '../../page-wrappers';
 
 const Festival = props => {
 
 	const { festival } = props;
 
-	const { productions } = festival;
+	const { festivalSeries, productions } = festival;
 
 	return (
 		<InstancePageWrapper instance={festival}>
+
+			{
+				festivalSeries && (
+					<InstanceFacet labelText='Festival series'>
+
+						<InstanceLink instance={festivalSeries} />
+
+					</InstanceFacet>
+				)
+			}
 
 			{
 				productions?.length > 0 && (

--- a/src/react/pages/instances/FestivalSeries.jsx
+++ b/src/react/pages/instances/FestivalSeries.jsx
@@ -2,14 +2,29 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
+import { InstanceFacet, InstanceLinksList } from '../../components';
 import { InstancePageWrapper } from '../../page-wrappers';
 
 const FestivalSeries = props => {
 
 	const { festivalSeries } = props;
 
+	const { festivals } = festivalSeries;
+
 	return (
-		<InstancePageWrapper instance={festivalSeries} />
+		<InstancePageWrapper instance={festivalSeries}>
+
+			{
+				festivals?.length > 0 && (
+					<InstanceFacet labelText='Comprises'>
+
+						<InstanceLinksList instances={festivals} />
+
+					</InstanceFacet>
+				)
+			}
+
+		</InstancePageWrapper>
 	);
 
 };

--- a/src/react/pages/instances/Production.jsx
+++ b/src/react/pages/instances/Production.jsx
@@ -8,6 +8,7 @@ import {
 	CommaSeparatedMaterials,
 	CommaSeparatedProductions,
 	Entities,
+	FestivalLinkWithContext,
 	InstanceFacet,
 	InstanceLink,
 	ListWrapper,
@@ -112,7 +113,7 @@ const Production = props => {
 					festival && (
 						<InstanceFacet labelText='Festival'>
 
-							<InstanceLink instance={festival} />
+							<FestivalLinkWithContext festival={festival} />
 
 						</InstanceFacet>
 					)

--- a/src/react/pages/lists/Festivals.jsx
+++ b/src/react/pages/lists/Festivals.jsx
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
 
-import { InstanceLinksList } from '../../components';
+import { InstanceLink, ListWrapper } from '../../components';
 import { ListPageWrapper } from '../../page-wrappers';
 
 const Festivals = props => {
@@ -12,7 +12,31 @@ const Festivals = props => {
 	return (
 		<ListPageWrapper pageTitleText='Festivals'>
 
-			<InstanceLinksList instances={festivals} />
+			<ListWrapper>
+
+				{
+					festivals.map((festival, index) =>
+						<li key={index}>
+
+							{
+								festival.festivalSeries && (
+									<>
+
+										<InstanceLink instance={festival.festivalSeries} />
+
+										<>{': '}</>
+
+									</>
+								)
+							}
+
+							<InstanceLink instance={festival} />
+
+						</li>
+					)
+				}
+
+			</ListWrapper>
 
 		</ListPageWrapper>
 	);


### PR DESCRIPTION
Display festival festival series (i.e. the festival series of which a festival is a run) exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/608.

---

#### Edinburgh International Festival 2006 (festival)
<img width="801" alt="edinburgh-international-festival-2006-festival" src="https://github.com/andygout/theatrebase-api/assets/10484515/ef4be010-4085-446c-8484-9a4ad5d7b436">

---

#### Edinburgh International Festival (festival series)
<img width="539" alt="edinburgh-international-festival-festival-series" src="https://github.com/andygout/theatrebase-api/assets/10484515/b98421fb-1a9f-4764-959b-66c9f07c7607">

---

#### Troilus and Cressida at King's Theatre (production)
<img width="604" alt="troilus-and-cressida-at-kings-theatre-production" src="https://github.com/andygout/theatrebase-api/assets/10484515/cc91d6e5-2749-4a85-addc-0f43e011cde5">

---

#### Festivals list
<img width="294" alt="festivals-list" src="https://github.com/andygout/theatrebase-api/assets/10484515/401dfce4-8be9-4a1f-9b49-736a33bd47d4">