### PR TITLE
Hyphenate 'variant-named' (depictions/portrayals)

### DIFF
--- a/src/react/pages/instances/Character.jsx
+++ b/src/react/pages/instances/Character.jsx
@@ -23,7 +23,7 @@ const Character = props => {
 
 			{
 				variantNamedDepictions?.length > 0 && (
-					<InstanceFacet labelText='Variant named depictions'>
+					<InstanceFacet labelText='Variant-named depictions'>
 
 						<span className="fictional-name-text">
 
@@ -65,7 +65,7 @@ const Character = props => {
 
 			{
 				variantNamedPortrayals?.length > 0 && (
-					<InstanceFacet labelText='Variant named portrayals'>
+					<InstanceFacet labelText='Variant-named portrayals'>
 
 						<span className="fictional-name-text">
 


### PR DESCRIPTION
This PR hyphenates 'variant-named' (in relation to depictions and portrayals):

> A compound modifier is made up of two or more words that work together to function like one adjective in describing a noun. When you connect words with a hyphen, you make it clear to readers that the words work together as a unit of meaning.

Ref. [Grammarly: Hypen Usage—Rules and Examples](https://www.grammarly.com/blog/hyphen)

### References:
- [Grammarly: Hypen Usage—Rules and Examples](https://www.grammarly.com/blog/hyphen)