### PR TITLE
Replace en dashes with em dashes

### DIFF
--- a/src/react/components/AppendedPerformers.jsx
+++ b/src/react/components/AppendedPerformers.jsx
@@ -10,7 +10,7 @@ const AppendedPerformers = props => {
 	return (
 		<>
 
-			<>{' - performed by: '}</>
+			<>{' — performed by: '}</>
 
 			{
 				performers

--- a/src/react/components/AppendedVenue.jsx
+++ b/src/react/components/AppendedVenue.jsx
@@ -10,7 +10,7 @@ const AppendedVenue = props => {
 	return (
 		<>
 
-			<>{' - '}</>
+			<>{' — '}</>
 
 			<VenueLinkWithContext venue={venue} />
 


### PR DESCRIPTION
This PR changes en dashes to em dashes.

> The en dash is approximately the length of the letter N, and the em dash the length of the letter M. The shorter en dash (–) is used to mark ranges and with the meaning “to” in phrases like “Dover–Calais crossing.” The longer em dash (—) is used to separate extra information or mark a break in a sentence.

Ref. [Scribbr: Em Dash (—) vs. En Dash (–) | How to Use in Sentences](https://www.scribbr.com/language-rules/dashes)

### References:
[Scribbr: Em Dash (—) vs. En Dash (–) | How to Use in Sentences](https://www.scribbr.com/language-rules/dashes)