### PR TITLE
Display company/person material productions

### DIFF
--- a/src/react/pages/instances/Company.jsx
+++ b/src/react/pages/instances/Company.jsx
@@ -14,7 +14,8 @@ import {
 	InstanceLink,
 	ListWrapper,
 	MaterialsList,
-	ProducerProductionsList
+	ProducerProductionsList,
+	ProductionsList
 } from '../../components';
 import { InstancePageWrapper } from '../../page-wrappers';
 
@@ -27,6 +28,10 @@ const Company = props => {
 		subsequentVersionMaterials,
 		sourcingMaterials,
 		rightsGrantorMaterials,
+		materialProductions,
+		subsequentVersionMaterialProductions,
+		sourcingMaterialProductions,
+		rightsGrantorMaterialProductions,
 		producerProductions,
 		creativeProductions,
 		crewProductions,
@@ -74,6 +79,46 @@ const Company = props => {
 					<InstanceFacet labelText='Materials as rights grantor'>
 
 						<MaterialsList materials={rightsGrantorMaterials} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				materialProductions?.length > 0 && (
+					<InstanceFacet labelText='Productions of materials'>
+
+						<ProductionsList productions={materialProductions} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				subsequentVersionMaterialProductions?.length > 0 && (
+					<InstanceFacet labelText='Productions of subsequent versions of their materials'>
+
+						<ProductionsList productions={subsequentVersionMaterialProductions} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				sourcingMaterialProductions?.length > 0 && (
+					<InstanceFacet labelText='Productions of materials as source material writer'>
+
+						<ProductionsList productions={sourcingMaterialProductions} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				rightsGrantorMaterialProductions?.length > 0 && (
+					<InstanceFacet labelText='Productions of materials as rights grantor'>
+
+						<ProductionsList productions={rightsGrantorMaterialProductions} />
 
 					</InstanceFacet>
 				)

--- a/src/react/pages/instances/Person.jsx
+++ b/src/react/pages/instances/Person.jsx
@@ -16,7 +16,8 @@ import {
 	ListWrapper,
 	MaterialsList,
 	ProducerProductionsList,
-	ProductionLinkWithContext
+	ProductionLinkWithContext,
+	ProductionsList
 } from '../../components';
 import { InstancePageWrapper } from '../../page-wrappers';
 
@@ -29,6 +30,10 @@ const Person = props => {
 		subsequentVersionMaterials,
 		sourcingMaterials,
 		rightsGrantorMaterials,
+		materialProductions,
+		subsequentVersionMaterialProductions,
+		sourcingMaterialProductions,
+		rightsGrantorMaterialProductions,
 		producerProductions,
 		castMemberProductions,
 		creativeProductions,
@@ -77,6 +82,46 @@ const Person = props => {
 					<InstanceFacet labelText='Materials as rights grantor'>
 
 						<MaterialsList materials={rightsGrantorMaterials} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				materialProductions?.length > 0 && (
+					<InstanceFacet labelText='Productions of materials'>
+
+						<ProductionsList productions={materialProductions} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				subsequentVersionMaterialProductions?.length > 0 && (
+					<InstanceFacet labelText='Productions of subsequent versions of their materials'>
+
+						<ProductionsList productions={subsequentVersionMaterialProductions} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				sourcingMaterialProductions?.length > 0 && (
+					<InstanceFacet labelText='Productions of materials as source material writer'>
+
+						<ProductionsList productions={sourcingMaterialProductions} />
+
+					</InstanceFacet>
+				)
+			}
+
+			{
+				rightsGrantorMaterialProductions?.length > 0 && (
+					<InstanceFacet labelText='Productions of materials as rights grantor'>
+
+						<ProductionsList productions={rightsGrantorMaterialProductions} />
 
 					</InstanceFacet>
 				)


### PR DESCRIPTION
This PR displays company/person material productions exposed by this API PR: https://github.com/andygout/theatrebase-api/pull/636.

E.g. for either a person or company it will display:
- productions of materials they wrote
- productions of subsequent versions of their materials
- productions of materials that used their work as source material
- productions of materials for which they granted rights

---

#### William Shakespeare (person)

> productions of materials they wrote

<img width="607" alt="prods-of-materials" src="https://github.com/andygout/theatrebase-api/assets/10484515/9d586bb7-6683-4f4f-a687-c7ed76520243">

---

> productions of subsequent versions of their materials

<img width="926" alt="prods-of-subsequent-versions-of-their-mats" src="https://github.com/andygout/theatrebase-api/assets/10484515/5fc0974b-634c-41fd-8c00-3029832c05e3">

---

> productions of materials that used their work as source material

<img width="609" alt="prods-of-mats-as-source-mat-writer" src="https://github.com/andygout/theatrebase-api/assets/10484515/5fa554d9-3151-40e0-901f-a91c83372862">

---

#### StudioCanal (company)

> productions of materials for which they granted rights

<img width="444" alt="prods-of-mats-as-rights-grantor" src="https://github.com/andygout/theatrebase-api/assets/10484515/bf89aed6-82b0-4678-bbe8-22acf1b24c62">