### PR TITLE
Re-order material credits

### DIFF
--- a/src/react/pages/instances/Material.jsx
+++ b/src/react/pages/instances/Material.jsx
@@ -33,9 +33,9 @@ const Material = props => {
 			characterGroups,
 			originalVersionMaterial,
 			subsequentVersionMaterials,
-			subsequentVersionMaterialProductions,
-			productions,
 			sourcingMaterials,
+			productions,
+			subsequentVersionMaterialProductions,
 			sourcingMaterialProductions,
 			awards,
 			subsequentVersionMaterialAwards,
@@ -199,10 +199,10 @@ const Material = props => {
 				}
 
 				{
-					subsequentVersionMaterialProductions?.length > 0 && (
-						<InstanceFacet labelText='Productions of subsequent versions'>
+					sourcingMaterials?.length > 0 && (
+						<InstanceFacet labelText='Materials as source material'>
 
-							<ProductionsList productions={subsequentVersionMaterialProductions} />
+							<MaterialsList materials={sourcingMaterials} />
 
 						</InstanceFacet>
 					)
@@ -219,10 +219,10 @@ const Material = props => {
 				}
 
 				{
-					sourcingMaterials?.length > 0 && (
-						<InstanceFacet labelText='Materials as source material'>
+					subsequentVersionMaterialProductions?.length > 0 && (
+						<InstanceFacet labelText='Productions of subsequent versions'>
 
-							<MaterialsList materials={sourcingMaterials} />
+							<ProductionsList productions={subsequentVersionMaterialProductions} />
 
 						</InstanceFacet>
 					)


### PR DESCRIPTION
This PR re-orders the material credits so that its materials and productions are grouped together respectively as they are for the equivalent company and person credits.