### PR TITLE
Display material/production subtitle

### DIFF
--- a/src/client/stylesheets/_text.scss
+++ b/src/client/stylesheets/_text.scss
@@ -7,6 +7,13 @@
 	color: color-variables.$default-text-color;
 }
 
+.subtitle-text {
+	margin: 0 5px 20px 5px;
+	padding-bottom: 0px;
+	font-size: x-large;
+	color: color-variables.$default-text-color;
+}
+
 .fictional-name-text {
 	font-style: italic;
 }

--- a/src/react/components/PageSubtitle.jsx
+++ b/src/react/components/PageSubtitle.jsx
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+const PageSubtitle = props => {
+
+	const { text } = props;
+
+	return (
+		<h1 className="subtitle-text">
+			{ text }
+		</h1>
+	);
+
+};
+
+PageSubtitle.propTypes = {
+	text: PropTypes.string.isRequired
+};
+
+export default PageSubtitle;

--- a/src/react/components/index.js
+++ b/src/react/components/index.js
@@ -31,6 +31,7 @@ import ListWrapper from './ListWrapper';
 import MaterialLinkWithContext from './MaterialLinkWithContext';
 import MaterialsList from './MaterialsList';
 import Navigation from './Navigation';
+import PageSubtitle from './PageSubtitle';
 import PageTitle from './PageTitle';
 import PrependedSurInstance from './PrependedSurInstance';
 import ProducerCredits from './ProducerCredits';
@@ -77,6 +78,7 @@ export {
 	MaterialLinkWithContext,
 	MaterialsList,
 	Navigation,
+	PageSubtitle,
 	PageTitle,
 	PrependedSurInstance,
 	ProducerCredits,

--- a/src/react/page-wrappers/InstancePageWrapper.jsx
+++ b/src/react/page-wrappers/InstancePageWrapper.jsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import getDifferentiatorSuffix from '../../lib/get-differentiator-suffix';
 import getInstanceTitle from '../../lib/get-instance-title';
-import { InstanceDocumentTitle, InstanceLabel, PageTitle } from '../components';
+import { InstanceDocumentTitle, InstanceLabel, PageSubtitle, PageTitle } from '../components';
 
 const InstancePageWrapper = props => {
 
@@ -36,6 +36,12 @@ const InstancePageWrapper = props => {
 			<InstanceLabel model={instance.model || ''} />
 
 			<PageTitle text={pageTitleText} />
+
+			{
+				instance.subtitle && (
+					<PageSubtitle text={instance.subtitle} />
+				)
+			}
 
 			{ children }
 

--- a/src/react/pages/instances/Material.jsx
+++ b/src/react/pages/instances/Material.jsx
@@ -85,6 +85,12 @@ const Material = props => {
 
 									<InstanceLink instance={surMaterial} />
 
+									{
+										surMaterial.subtitle && (
+											<p>{ surMaterial.subtitle }</p>
+										)
+									}
+
 								</InstanceFacet>
 
 								{
@@ -109,6 +115,12 @@ const Material = props => {
 										<InstanceFacet labelText='Material'>
 
 											<InstanceLink instance={subMaterial} />
+
+											{
+												subMaterial.subtitle && (
+													<p>{ subMaterial.subtitle }</p>
+												)
+											}
 
 										</InstanceFacet>
 

--- a/src/react/pages/instances/Production.jsx
+++ b/src/react/pages/instances/Production.jsx
@@ -129,6 +129,12 @@ const Production = props => {
 
 									<InstanceLink instance={surProduction} />
 
+									{
+										surProduction.subtitle && (
+											<p>{ surProduction.subtitle }</p>
+										)
+									}
+
 								</InstanceFacet>
 
 								{
@@ -153,6 +159,12 @@ const Production = props => {
 										<InstanceFacet labelText='Production'>
 
 											<InstanceLink instance={subProduction} />
+
+											{
+												subProduction.subtitle && (
+													<p>{ subProduction.subtitle }</p>
+												)
+											}
 
 										</InstanceFacet>
 


### PR DESCRIPTION
This PR adds functionality to be able to display material/production subtitle as implemented in this API PR: https://github.com/andygout/theatrebase-api/pull/644.

---

#### Angels in America (material)
<img width="470" alt="angels-in-america" src="https://github.com/andygout/theatrebase-api/assets/10484515/145c22cd-d482-44c5-aefd-15625d39c408">

---

#### Millennium Approaches (material)
<img width="952" alt="millenium-approaches" src="https://github.com/andygout/theatrebase-api/assets/10484515/d38e44a6-5dfa-4c43-8432-b46589386928">

---

#### Tonight At 8.30 (material)
<img width="960" alt="tonight-at-8-30" src="https://github.com/andygout/theatrebase-api/assets/10484515/b1ddb73b-fbcb-4ae9-818f-9038d4e5b1d1">

---

#### We Were Dancing (material)
<img width="337" alt="we-were-dancing" src="https://github.com/andygout/theatrebase-api/assets/10484515/f640d805-6dd0-489e-bfc8-2050646d4e09">

---

#### Henry VI at Courtyard Theatre (production)
<img width="362" alt="henry-vi-part-1-courtyard-theatre" src="https://github.com/andygout/theatrebase-api/assets/10484515/4ae895cc-43d3-46a6-93f6-a7d0f4ff7997">