### PR TITLE
Remove ESLint rules overridden by Prettier

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,7 +40,6 @@ export default [
 					}
 				}
 			],
-			'comma-dangle': 'error',
 			eqeqeq: 'error',
 			'guard-for-in': 'error',
 			'new-cap': 'error',
@@ -49,19 +48,12 @@ export default [
 			'no-extend-native': 'error',
 			'no-irregular-whitespace': 'error',
 			'no-loop-func': 'error',
-			'no-multi-spaces': 'error',
-			'no-multiple-empty-lines': ['error', { max: 1 }],
 			'no-undef': 'error',
 			'no-underscore-dangle': 'error',
 			'no-unused-vars': 'error',
 			'no-var': 'error',
 			'one-var': ['error', 'never'],
-			quotes: ['error', 'single'],
-			semi: 'error',
-			'space-before-function-paren': 'error',
-			'spaced-comment': 'error',
-			strict: ['error', 'global'],
-			'wrap-iife': 'error'
+			strict: ['error', 'global']
 		}
 	},
 	{


### PR DESCRIPTION
This PR removes ESLint rules that are overridden by the `eslintConfigPrettier` entry.

ChatGPT:

> You have this at the end [of `eslint.config.js`]:
>
> ```js
> eslintConfigPrettier
> ```
>
> `eslint-config-prettier` turns off rules that are unnecessary or that conflict with Prettier. That means stylistic rules such as `space-before-function-paren` are being disabled by that final config entry, so ESLint is no longer enforcing or fixing them.
>
> So in your specific config, this rule:
>
> ```js
> 'space-before-function-paren': 'error',
> ```
>
> is effectively neutralized by the later `eslintConfigPrettier` entry. In flat config, later config entries win when they overlap. That is why changing:
>
> ```js
> async function performFetch(url, instance, modelEmoji, filenamePathSlug) {
> ```
>
> to:
>
> ```js
> async function performFetch (url, instance, modelEmoji, filenamePathSlug) {
> ```
>
> did not produce an ESLint fix.