### PR TITLE
Update header text colour

### DIFF
--- a/src/client/stylesheets/lib/color-variables.css
+++ b/src/client/stylesheets/lib/color-variables.css
@@ -13,8 +13,8 @@
 	--content-background-color: #ffffff;
 	--default-text-color: #404040;
 	--header-background-color: #000000;
-	--header-text-color: #1975a3;
-	--header-text-color-hover: #3083ac;
+	--header-text-color: #60abd6;
+	--header-text-color-hover: #a5daf8;
 	--html-background-color: #f0f0f0;
 	--interactive-text-color: #006699;
 	--nested-instance-background-color: #f8f8f8;


### PR DESCRIPTION
This PR updates the header text colour so that there is a higher contrast making it more readable.

The hover state colour has also been made lighter as well to compensate.

### Before
<img width="369" height="76" alt="header-link-before" src="https://github.com/user-attachments/assets/607b1316-85b5-4c19-b9e8-63e7658aa012" />

### After
<img width="374" height="78" alt="header-link-after" src="https://github.com/user-attachments/assets/3b7f7acb-b191-4cab-9a81-20836a083741" />