### PR TITLE
Reset clickable area of header home page link

### DIFF
--- a/src/client/stylesheets/header.css
+++ b/src/client/stylesheets/header.css
@@ -11,7 +11,8 @@
 }
 
 .header__home-link {
-	display: flex;
+	display: inline-flex;
+	vertical-align: bottom;
 	align-items: center;
 	gap: 10px;
 	line-height: 1;


### PR DESCRIPTION
The changes in this PR https://github.com/andygout/dramatis-spa/pull/293 unintentionally increased the clickable area of the header home page link.

This PR reverts it to its previous state.

### Before
<img width="1004" height="110" alt="home-link-before" src="https://github.com/user-attachments/assets/1c696467-17cb-4d1d-9e6d-bd6a8c185d88" />

### After
<img width="1004" height="110" alt="home-link-after" src="https://github.com/user-attachments/assets/4786edfd-4499-4e0d-aa0f-0ce212eca593" />