### PR TITLE
Handle unfound paths in API router

### DIFF
--- a/src/server/api-router.js
+++ b/src/server/api-router.js
@@ -66,4 +66,11 @@ router.get('/venues', (request, response, next) => listsController(request, resp
 
 router.get('/venues/:uuid', (request, response, next) => instancesController(request, response, next));
 
+router.use((request, response, next) => {
+	const error = new Error('Not Found');
+	error.status = 404;
+
+	return next(error);
+});
+
 export default router;


### PR DESCRIPTION
This PR adds handling for unfound paths in the API router.

Below examples are from when a request is made to `/locales` if the [corresponding route](https://github.com/andygout/dramatis-spa/blob/a7e7b5502d2e881e721fc772f8a38c47712633e4/src/server/api-router.js#L35) is commented out.

### Before

Currently, if the client makes a request to the API with a path that it cannot find then the response looks like:

<img width="1005" height="669" alt="api-router-before" src="https://github.com/user-attachments/assets/8b37f0d7-042e-48ae-8174-eae9ecdf4111" />

### After
<img width="1004" height="669" alt="api-router-after" src="https://github.com/user-attachments/assets/43fc1580-9ae7-4dc4-91ba-ef89918629d5" />