### PR TITLE
Group API router paths by resource

### DIFF
--- a/src/server/api-router.js
+++ b/src/server/api-router.js
@@ -9,61 +9,47 @@ import {
 const router = new Router();
 
 router.get('/awards', (request, response, next) => listsController(request, response, next));
-
 router.get('/awards/:uuid', (request, response, next) => instancesController(request, response, next));
 
 router.get('/award-ceremonies', (request, response, next) => listsController(request, response, next));
-
 router.get('/award-ceremonies/:uuid', (request, response, next) => instancesController(request, response, next));
 
 router.get('/characters', (request, response, next) => listsController(request, response, next));
-
 router.get('/characters/:uuid', (request, response, next) => instancesController(request, response, next));
 
 router.get('/companies', (request, response, next) => listsController(request, response, next));
-
 router.get('/companies/:uuid', (request, response, next) => instancesController(request, response, next));
 
 router.get('/festivals', (request, response, next) => listsController(request, response, next));
-
 router.get('/festivals/:uuid', (request, response, next) => instancesController(request, response, next));
 
 router.get('/festival-serieses', (request, response, next) => listsController(request, response, next));
-
 router.get('/festival-serieses/:uuid', (request, response, next) => instancesController(request, response, next));
 
 router.get('/locales', (request, response, next) => listsController(request, response, next));
-
 router.get('/locales/:uuid', (request, response, next) => instancesController(request, response, next));
 
 router.get('/materials', (request, response, next) => listsController(request, response, next));
-
 router.get('/materials/:uuid', (request, response, next) => instancesController(request, response, next));
 
 router.get('/people', (request, response, next) => listsController(request, response, next));
-
 router.get('/people/:uuid', (request, response, next) => instancesController(request, response, next));
 
 router.get('/places', (request, response, next) => listsController(request, response, next));
-
 router.get('/places/:uuid', (request, response, next) => instancesController(request, response, next));
 
 router.get('/productions', (request, response, next) => listsController(request, response, next));
-
 router.get('/productions/:uuid', (request, response, next) => instancesController(request, response, next));
 
 router.get('/seasons', (request, response, next) => listsController(request, response, next));
-
 router.get('/seasons/:uuid', (request, response, next) => instancesController(request, response, next));
 
 router.get('/times', (request, response, next) => listsController(request, response, next));
-
 router.get('/times/:uuid', (request, response, next) => instancesController(request, response, next));
 
 router.get('/search', (request, response, next) => searchController(request, response, next));
 
 router.get('/venues', (request, response, next) => listsController(request, response, next));
-
 router.get('/venues/:uuid', (request, response, next) => instancesController(request, response, next));
 
 router.use((request, response, next) => {


### PR DESCRIPTION
As the number of resources increases, it makes sense to group their paths in the API router together.