### PR TITLE
Display setting materials settings property

### DIFF
--- a/src/react/components/AppendedSettings.jsx
+++ b/src/react/components/AppendedSettings.jsx
@@ -1,0 +1,44 @@
+import { Fragment } from 'react';
+
+import InstanceLink from './InstanceLink.jsx';
+
+const AppendedSettings = (props) => {
+	const { settings } = props;
+
+	return (
+		<Fragment>
+			<Fragment>{' — '}</Fragment>
+
+			{settings
+				.map((setting, index) => (
+					<Fragment key={index}>
+						{[
+							setting.time && (
+								<Fragment>
+									{'time: '}
+									<InstanceLink instance={setting.time} />
+								</Fragment>
+							),
+							setting.place && (
+								<Fragment>
+									{'place: '}
+									<InstanceLink instance={setting.place} />
+								</Fragment>
+							),
+							setting.locale && (
+								<Fragment>
+									{'locale: '}
+									<InstanceLink instance={setting.locale} />
+								</Fragment>
+							)
+						]
+							.filter(Boolean)
+							.reduce((accumulator, currentValue) => [accumulator, ', ', currentValue])}
+					</Fragment>
+				))
+				.reduce((accumulator, currentValue) => [accumulator, ' / ', currentValue])}
+		</Fragment>
+	);
+};
+
+export default AppendedSettings;

--- a/src/react/components/MaterialLinkWithContext.jsx
+++ b/src/react/components/MaterialLinkWithContext.jsx
@@ -1,4 +1,5 @@
 import AppendedFormatAndYear from './AppendedFormatAndYear.jsx';
+import AppendedSettings from './AppendedSettings.jsx';
 import InstanceLink from './InstanceLink.jsx';
 import PrependedSurInstance from './PrependedSurInstance.jsx';
 import WritingCredits from './WritingCredits.jsx';
@@ -27,6 +28,8 @@ const MaterialLinkWithContext = (props) => {
 					<WritingCredits credits={material.writingCredits} isAppendage={true} />
 				</>
 			)}
+
+			{material.settings?.length > 0 && <AppendedSettings settings={material.settings} />}
 		</>
 	);
 };

--- a/src/react/components/index.js
+++ b/src/react/components/index.js
@@ -10,6 +10,7 @@ import AppendedProductionDates from './AppendedProductionDates.jsx';
 import AppendedProductionTeamCredits from './AppendedProductionTeamCredits.jsx';
 import AppendedQualifier from './AppendedQualifier.jsx';
 import AppendedRoles from './AppendedRoles.jsx';
+import AppendedSettings from './AppendedSettings.jsx';
 import AppendedVenue from './AppendedVenue.jsx';
 import CharactersList from './CharactersList.jsx';
 import CommaSeparatedInstanceLinks from './CommaSeparatedInstanceLinks.jsx';
@@ -59,6 +60,7 @@ export {
 	AppendedProductionTeamCredits,
 	AppendedQualifier,
 	AppendedRoles,
+	AppendedSettings,
 	AppendedVenue,
 	CharactersList,
 	CommaSeparatedInstanceLinks,


### PR DESCRIPTION
This PR displays the `settings` property added to setting materials (so as to provide contextual information about the other setting elements) as made available by this dramatis-api PR: https://github.com/andygout/dramatis-api/pull/750.

#### 2001 (time)
Multiple materials that share the same time setting.

<img width="736" height="247" alt="2001-time" src="https://github.com/user-attachments/assets/f2c0552c-dab5-494e-979d-96e1ce8b8d5c" />

---

#### 490 BC (time)
A material that has multiple settings that include the same time setting.

<img width="943" height="200" alt="time-490-bc" src="https://github.com/user-attachments/assets/712e6fa3-61ec-4e36-8ab2-d843262ed3e8" />

---

#### Rome (place)
Multiple materials that share the same place setting. (Coincidentally, these also all have multiple settings that include the same place setting)

<img width="955" height="280" alt="place-rome" src="https://github.com/user-attachments/assets/dcdc0b2a-9e1a-41a7-ae06-8401af933ff3" />

---

#### Derbyshire (place)
A material that has multiple settings that include the same place setting.

<img width="902" height="185" alt="place-derbyshire" src="https://github.com/user-attachments/assets/5d6e84a0-4e37-4627-bdb4-9fe50264a8b2" />

---

#### Battlefield (locale)
Multiple materials that share the same locale setting.

<img width="655" height="210" alt="locale-battlefield" src="https://github.com/user-attachments/assets/73ea46c2-33ce-47ab-8d7a-aad132b5d3f5" />

---

#### Stately home (locale)
A material that has multiple settings that include the same locale setting.

<img width="902" height="190" alt="locale-stately-home" src="https://github.com/user-attachments/assets/7de25f59-6823-44cd-a018-b7a60d8d7f3b" />